### PR TITLE
Update dependencies and test runner.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,11 +14,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.1]
-        laravel: [9.*]
+        laravel: [9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
+            carbon: ^2.63
+          - laravel: 10.*
+            testbench: 8.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ All notable changes to `laravel-ddd` will be documented in this file.
 
 ### Changed
 - Install command now publishes config, registers the default domain path in composer.json, and prompts to publish stubs.
-- Generator command signatures simplified to `ddd:*` (previously `ddd:make:*`). 
+- Generator command signatures simplified to `ddd:*` (previously `ddd:make:*`).
+
+### Fixed
+- When ViewModels are generated, base view model import statement is now properly substituted.
 
 ## [0.1.0] - 2023-01-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
-## [Unversioned]
+## [0.2.0] - 2023-02-20
+### Added
+- Support for Laravel 10.
+
 ### Changed
 - Install command now publishes config, registers the default domain path in composer.json, and prompts to publish stubs.
+- Generator command signatures simplified to `ddd:*` (previously `ddd:make:*`). 
 
 ## [0.1.0] - 2023-01-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/lunarstorm/laravel-ddd/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/lunarstorm/laravel-ddd/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/lunarstorm/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/lunarstorm/laravel-ddd)
 
-Laravel-DDD is a toolkit to support domain driven design (DDD) patterns in Laravel applications. One of the pain points when adopting DDD is the inability to use Laravel's native `make:model` artisan command to properly generate domain models, since domain models are not intended to be stored in the `App/Models/*` namespace. This package aims to fill the gaps by providing an equivalent command, `ddd:make:model`, plus a few more.
+Laravel-DDD is a toolkit to support domain driven design (DDD) patterns in Laravel applications. One of the pain points when adopting DDD is the inability to use Laravel's native `make:model` artisan command to properly generate domain models, since domain models are not intended to be stored in the `App/Models/*` namespace. This package aims to fill the gaps by providing an equivalent command, `ddd:model`, plus a few more.
 
 > :warning: **Disclaimer**: While this package is publicly available for installation, it is subject to frequent design changes as it evolves towards a stable v1.0 release. It is currently being tested and fine tuned within Lunarstorm's client projects.
 
@@ -28,23 +28,23 @@ The following generator commands are currently available:
 
 ```bash
 # Generate a domain model
-php artisan ddd:make:model {domain} {name}
+php artisan ddd:model {domain} {name}
 
 # Generate a data transfer object
-php artisan ddd:make:dto {domain} {name}
+php artisan ddd:dto {domain} {name}
 
 # Generates a value object
-php artisan ddd:make:value {domain} {name}
+php artisan ddd:value {domain} {name}
 
 # Generates a view model
-php artisan ddd:make:view-model {domain} {name}
+php artisan ddd:view-model {domain} {name}
 ```
 Examples:
 ```bash
-php artisan ddd:make:model Invoicing LineItem # Domains/Invoicing/Models/LineItem
-php artisan ddd:make:dto Invoicing LinePayload # Domains/Invoicing/Data/LinePayload
-php artisan ddd:make:value Shared Percentage # Domains/Shared/ValueObjects/Percentage
-php artisan ddd:make:view-model Invoicing ShowInvoiceViewModel # Domains/Invoicing/ViewModels/ShowInvoiceViewModel
+php artisan ddd:model Invoicing LineItem # Domains/Invoicing/Models/LineItem
+php artisan ddd:dto Invoicing LinePayload # Domains/Invoicing/Data/LinePayload
+php artisan ddd:value Shared Percentage # Domains/Shared/ValueObjects/Percentage
+php artisan ddd:view-model Invoicing ShowInvoiceViewModel # Domains/Invoicing/ViewModels/ShowInvoiceViewModel
 ```
 
 This package ships with opinionated (but sensible) configuration defaults. If you need to customize, you may do so by publishing the config file and generator stubs as needed:

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "authors": [
         {
             "name": "Jasper Tey",
-            "email": "jasper@jtey.com",
+            "email": "jasper@lunarstorm.ca",
             "role": "Developer"
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.1|^8.2",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0"
+        "illuminate/contracts": "^9.0|^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/config/ddd.php
+++ b/config/ddd.php
@@ -92,4 +92,16 @@ return [
     |
     */
     'base_dto' => 'Spatie\LaravelData\Data',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base ViewModel
+    |--------------------------------------------------------------------------
+    |
+    | This base view model which generated view models should extend. By default,
+    | generated domain models will extend `Domains\Shared\ViewModels\BaseViewModel`,
+    | which will be created if it doesn't already exist.
+    |
+    */
+    'base_view_model' => 'Domains\Shared\ViewModels\ViewModel',
 ];

--- a/src/Commands/MakeBaseModel.php
+++ b/src/Commands/MakeBaseModel.php
@@ -11,7 +11,7 @@ class MakeBaseModel extends DomainGeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'ddd:make:base-model {domain} {name=BaseModel}';
+    protected $signature = 'ddd:base-model {domain} {name=BaseModel}';
 
     /**
      * The console command description.

--- a/src/Commands/MakeBaseViewModel.php
+++ b/src/Commands/MakeBaseViewModel.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Commands;
+
+use Illuminate\Console\Command;
+
+class MakeBaseViewModel extends DomainGeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ddd:base-view-model {domain} {name=ViewModel}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a base view model';
+
+    protected $type = 'ViewModel';
+
+    protected function getStub()
+    {
+        return $this->resolveStubPath('base-view-model.php.stub');
+    }
+
+    protected function getRelativeDomainNamespace(): string
+    {
+        return config('ddd.namespaces.view_models', 'ViewModels');
+    }
+}

--- a/src/Commands/MakeDTO.php
+++ b/src/Commands/MakeDTO.php
@@ -11,7 +11,7 @@ class MakeDTO extends DomainGeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'ddd:make:dto {domain} {name}';
+    protected $signature = 'ddd:dto {domain} {name}';
 
     /**
      * The console command description.

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -11,7 +11,7 @@ class MakeModel extends DomainGeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'ddd:make:model {domain} {name}';
+    protected $signature = 'ddd:model {domain} {name}';
 
     /**
      * The console command description.
@@ -41,7 +41,7 @@ class MakeModel extends DomainGeneratorCommand
         $baseModelPath = $this->getPath($baseModel);
         // dd($baseModelPath);
 
-        if (! file_exists($baseModelPath)) {
+        if (!file_exists($baseModelPath)) {
             $this->warn("Base model {$baseModel} doesn't exist, generating...");
 
             // dd($baseModel, $baseModelName);

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -40,7 +40,7 @@ class MakeModel extends DomainGeneratorCommand
         $baseModelName = $parts->last();
         $baseModelPath = $this->getPath($baseModel);
 
-        if (!file_exists($baseModelPath)) {
+        if (! file_exists($baseModelPath)) {
             $this->warn("Base model {$baseModel} doesn't exist, generating...");
 
             $this->call(MakeBaseModel::class, [

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -39,19 +39,14 @@ class MakeModel extends DomainGeneratorCommand
         $parts = str($baseModel)->explode('\\');
         $baseModelName = $parts->last();
         $baseModelPath = $this->getPath($baseModel);
-        // dd($baseModelPath);
 
         if (!file_exists($baseModelPath)) {
             $this->warn("Base model {$baseModel} doesn't exist, generating...");
-
-            // dd($baseModel, $baseModelName);
 
             $this->call(MakeBaseModel::class, [
                 'domain' => 'Shared',
                 'name' => $baseModelName,
             ]);
-        } else {
-            // dd('file exists', $baseModelPath);
         }
 
         parent::handle();

--- a/src/Commands/MakeValueObject.php
+++ b/src/Commands/MakeValueObject.php
@@ -11,7 +11,7 @@ class MakeValueObject extends DomainGeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'ddd:make:value {domain} {name}';
+    protected $signature = 'ddd:value {domain} {name}';
 
     /**
      * The console command description.

--- a/src/Commands/MakeViewModel.php
+++ b/src/Commands/MakeViewModel.php
@@ -40,7 +40,7 @@ class MakeViewModel extends DomainGeneratorCommand
         $baseName = $parts->last();
         $basePath = $this->getPath($baseViewModel);
 
-        if (!file_exists($basePath)) {
+        if (! file_exists($basePath)) {
             $this->warn("Base view model {$baseViewModel} doesn't exist, generating...");
 
             $this->call(MakeBaseViewModel::class, [

--- a/src/Commands/MakeViewModel.php
+++ b/src/Commands/MakeViewModel.php
@@ -31,4 +31,24 @@ class MakeViewModel extends DomainGeneratorCommand
     {
         return $this->resolveStubPath('view-model.php.stub');
     }
+
+    public function handle()
+    {
+        $baseViewModel = config('ddd.base_view_model');
+
+        $parts = str($baseViewModel)->explode('\\');
+        $baseName = $parts->last();
+        $basePath = $this->getPath($baseViewModel);
+
+        if (!file_exists($basePath)) {
+            $this->warn("Base view model {$baseViewModel} doesn't exist, generating...");
+
+            $this->call(MakeBaseViewModel::class, [
+                'domain' => 'Shared',
+                'name' => $baseName,
+            ]);
+        }
+
+        parent::handle();
+    }
 }

--- a/src/Commands/MakeViewModel.php
+++ b/src/Commands/MakeViewModel.php
@@ -11,7 +11,7 @@ class MakeViewModel extends DomainGeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'ddd:make:view-model {domain} {name}';
+    protected $signature = 'ddd:view-model {domain} {name}';
 
     /**
      * The console command description.

--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -4,6 +4,7 @@ namespace Lunarstorm\LaravelDDD;
 
 use Lunarstorm\LaravelDDD\Commands\InstallCommand;
 use Lunarstorm\LaravelDDD\Commands\MakeBaseModel;
+use Lunarstorm\LaravelDDD\Commands\MakeBaseViewModel;
 use Lunarstorm\LaravelDDD\Commands\MakeDTO;
 use Lunarstorm\LaravelDDD\Commands\MakeModel;
 use Lunarstorm\LaravelDDD\Commands\MakeValueObject;
@@ -30,6 +31,7 @@ class LaravelDDDServiceProvider extends PackageServiceProvider
                 MakeDTO::class,
                 MakeValueObject::class,
                 MakeViewModel::class,
+                MakeBaseViewModel::class,
             ]);
     }
 

--- a/stubs/view-model.php.stub
+++ b/stubs/view-model.php.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use {{ baseViewModel }};
+use {{ rootNamespace }}\Shared\ViewModels\ViewModel;
 
 class {{ class }} extends ViewModel
 {

--- a/tests/Generator/MakeBaseModelTest.php
+++ b/tests/Generator/MakeBaseModelTest.php
@@ -19,7 +19,7 @@ it('can generate domain base model', function () {
 
     expect(file_exists($expectedModelPath))->toBeFalse();
 
-    Artisan::call("ddd:make:base-model {$domain} {$modelName}");
+    Artisan::call("ddd:base-model {$domain} {$modelName}");
 
     expect(file_exists($expectedModelPath))->toBeTrue();
 });

--- a/tests/Generator/MakeBaseViewModelTest.php
+++ b/tests/Generator/MakeBaseViewModelTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+it('can generate base view model', function () {
+    $className = 'ViewModel';
+    $domain = 'Shared';
+
+    $expectedPath = base_path(implode('/', [
+        config('ddd.paths.domains'),
+        $domain,
+        config('ddd.namespaces.view_models'),
+        "{$className}.php",
+    ]));
+
+    if (file_exists($expectedPath)) {
+        unlink($expectedPath);
+    }
+
+    expect(file_exists($expectedPath))->toBeFalse();
+
+    Artisan::call("ddd:base-view-model {$domain} {$className}");
+
+    expect(file_exists($expectedPath))->toBeTrue();
+});

--- a/tests/Generator/MakeDataTransferObjectTest.php
+++ b/tests/Generator/MakeDataTransferObjectTest.php
@@ -21,7 +21,7 @@ it('can generate data transfer objects', function () {
 
     expect(file_exists($expectedPath))->toBeFalse();
 
-    Artisan::call("ddd:make:dto {$domain} {$dtoName}");
+    Artisan::call("ddd:dto {$domain} {$dtoName}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
@@ -47,7 +47,7 @@ it('can generate data transfer objects in custom domain folder', function () {
 
     expect(file_exists($expectedPath))->toBeFalse();
 
-    Artisan::call("ddd:make:dto {$domain} {$dtoName}");
+    Artisan::call("ddd:dto {$domain} {$dtoName}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
@@ -62,7 +62,7 @@ it('normalizes generated data transfer object to pascal case', function ($given,
         "{$normalized}.php",
     ]));
 
-    Artisan::call("ddd:make:dto {$domain} {$given}");
+    Artisan::call("ddd:dto {$domain} {$given}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 })->with([

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -21,7 +21,7 @@ it('can generate domain models', function () {
 
     expect(file_exists($expectedModelPath))->toBeFalse();
 
-    Artisan::call("ddd:make:model {$domain} {$modelName}");
+    Artisan::call("ddd:model {$domain} {$modelName}");
 
     expect(file_exists($expectedModelPath))->toBeTrue();
 });
@@ -47,7 +47,7 @@ it('can generate domain models in custom domain folder', function () {
 
     expect(file_exists($expectedModelPath))->toBeFalse();
 
-    Artisan::call("ddd:make:model {$domain} {$modelName}");
+    Artisan::call("ddd:model {$domain} {$modelName}");
 
     expect(file_exists($expectedModelPath))->toBeTrue();
 });
@@ -62,7 +62,7 @@ it('normalizes generated model to pascal case', function ($given, $normalized) {
         "{$normalized}.php",
     ]));
 
-    Artisan::call("ddd:make:model {$domain} {$given}");
+    Artisan::call("ddd:model {$domain} {$given}");
 
     expect(file_exists($expectedModelPath))->toBeTrue();
 })->with([
@@ -99,7 +99,7 @@ it('generates the base model if needed', function () {
 
     expect(file_exists($expectedBaseModelPath))->toBeFalse();
 
-    Artisan::call("ddd:make:model {$domain} {$modelName}");
+    Artisan::call("ddd:model {$domain} {$modelName}");
 
     expect(file_exists($expectedBaseModelPath))->toBeTrue();
 });

--- a/tests/Generator/MakeValueObjectTest.php
+++ b/tests/Generator/MakeValueObjectTest.php
@@ -21,7 +21,7 @@ it('can generate value objects', function () {
 
     expect(file_exists($expectedPath))->toBeFalse();
 
-    Artisan::call("ddd:make:value {$domain} {$valueObjectName}");
+    Artisan::call("ddd:value {$domain} {$valueObjectName}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
@@ -47,7 +47,7 @@ it('can generate value objects in custom domain folder', function () {
 
     expect(file_exists($expectedPath))->toBeFalse();
 
-    Artisan::call("ddd:make:value {$domain} {$valueObjectName}");
+    Artisan::call("ddd:value {$domain} {$valueObjectName}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
@@ -62,7 +62,7 @@ it('normalizes generated value object to pascal case', function ($given, $normal
         "{$normalized}.php",
     ]));
 
-    Artisan::call("ddd:make:value {$domain} {$given}");
+    Artisan::call("ddd:value {$domain} {$given}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 })->with([

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -70,3 +70,30 @@ it('normalizes generated view model to pascal case', function ($given, $normaliz
     'ShowInvoiceViewModel' => ['ShowInvoiceViewModel', 'ShowInvoiceViewModel'],
     'show-invoice-view-model' => ['show-invoice-view-model', 'ShowInvoiceViewModel'],
 ]);
+
+it('generates the base view model if needed', function () {
+    $className = Str::studly(fake()->word());
+    $domain = Str::studly(fake()->word());
+
+    $expectedPath = base_path(implode('/', [
+        config('ddd.paths.domains'),
+        $domain,
+        config('ddd.namespaces.view_models'),
+        "{$className}.php",
+    ]));
+
+    if (file_exists($expectedPath)) {
+        unlink($expectedPath);
+    }
+
+    expect(file_exists($expectedPath))->toBeFalse();
+
+    // This currently only tests for the default base model
+    $expectedBaseViewModelPath = base_path('src/Domains/Shared/ViewModels/ViewModel.php');
+
+    expect(file_exists($expectedBaseViewModelPath))->toBeFalse();
+
+    Artisan::call("ddd:view-model {$domain} {$className}");
+
+    expect(file_exists($expectedBaseViewModelPath))->toBeTrue();
+});

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -21,7 +21,7 @@ it('can generate view models', function () {
 
     expect(file_exists($expectedPath))->toBeFalse();
 
-    Artisan::call("ddd:make:view-model {$domain} {$viewModelName}");
+    Artisan::call("ddd:view-model {$domain} {$viewModelName}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
@@ -47,7 +47,7 @@ it('can generate view models in custom domain folder', function () {
 
     expect(file_exists($expectedPath))->toBeFalse();
 
-    Artisan::call("ddd:make:view-model {$domain} {$viewModelName}");
+    Artisan::call("ddd:view-model {$domain} {$viewModelName}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
@@ -62,7 +62,7 @@ it('normalizes generated view model to pascal case', function ($given, $normaliz
         "{$normalized}.php",
     ]));
 
-    Artisan::call("ddd:make:view-model {$domain} {$given}");
+    Artisan::call("ddd:view-model {$domain} {$given}");
 
     expect(file_exists($expectedPath))->toBeTrue();
 })->with([


### PR DESCRIPTION
Support for Laravel 10.

## [0.2.0] - 2023-02-20
### Added
- Support for Laravel 10.

### Changed
- Install command now publishes config, registers the default domain path in composer.json, and prompts to publish stubs.
- Generator command signatures simplified to `ddd:*` (previously `ddd:make:*`).

### Fixed
- When ViewModels are generated, base view model import statement is now properly substituted. (closes #5)