### PR TITLE
Ensure `PromptsForMissingInput` is supported well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [Unversioned]
+### Changed
+- Update argument definitions across generator commands so that it plays nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.
+
 ## [0.3.0] - 2023-03-23
 ### Added
 - Increase test coverage to ensure expected namespaces are present in generated objects.

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -4,9 +4,21 @@ namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
 
 abstract class DomainGeneratorCommand extends GeneratorCommand
 {
+    protected function getArguments()
+    {
+        return [
+            new InputArgument(
+                'domain',
+                InputArgument::REQUIRED,
+                'The domain'
+            ),
+        ];
+    }
+
     protected function rootNamespace()
     {
         return str($this->getDomainBasePath())
@@ -19,7 +31,7 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
     {
         $domain = $this->getDomain();
 
-        return $rootNamespace.'\\'.$domain.'\\'.$this->getRelativeDomainNamespace();
+        return $rootNamespace . '\\' . $domain . '\\' . $this->getRelativeDomainNamespace();
     }
 
     abstract protected function getRelativeDomainNamespace(): string;
@@ -51,17 +63,17 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->getDomainBasePath().'/'.str_replace('\\', '/', $name).'.php';
+        return $this->getDomainBasePath() . '/' . str_replace('\\', '/', $name) . '.php';
     }
 
     protected function resolveStubPath($path)
     {
         $path = ltrim($path, '/\\');
 
-        $publishedPath = resource_path('stubs/ddd/'.$path);
+        $publishedPath = resource_path('stubs/ddd/' . $path);
 
         return file_exists($publishedPath)
             ? $publishedPath
-            : __DIR__.DIRECTORY_SEPARATOR.'../../stubs'.DIRECTORY_SEPARATOR.$path;
+            : __DIR__ . DIRECTORY_SEPARATOR . '../../stubs' . DIRECTORY_SEPARATOR . $path;
     }
 }

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -31,7 +31,7 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
     {
         $domain = $this->getDomain();
 
-        return $rootNamespace . '\\' . $domain . '\\' . $this->getRelativeDomainNamespace();
+        return $rootNamespace.'\\'.$domain.'\\'.$this->getRelativeDomainNamespace();
     }
 
     abstract protected function getRelativeDomainNamespace(): string;
@@ -63,17 +63,17 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
-        return $this->getDomainBasePath() . '/' . str_replace('\\', '/', $name) . '.php';
+        return $this->getDomainBasePath().'/'.str_replace('\\', '/', $name).'.php';
     }
 
     protected function resolveStubPath($path)
     {
         $path = ltrim($path, '/\\');
 
-        $publishedPath = resource_path('stubs/ddd/' . $path);
+        $publishedPath = resource_path('stubs/ddd/'.$path);
 
         return file_exists($publishedPath)
             ? $publishedPath
-            : __DIR__ . DIRECTORY_SEPARATOR . '../../stubs' . DIRECTORY_SEPARATOR . $path;
+            : __DIR__.DIRECTORY_SEPARATOR.'../../stubs'.DIRECTORY_SEPARATOR.$path;
     }
 }

--- a/src/Commands/MakeBaseModel.php
+++ b/src/Commands/MakeBaseModel.php
@@ -28,7 +28,7 @@ class MakeBaseModel extends DomainGeneratorCommand
                 InputArgument::OPTIONAL,
                 'The name of the base model',
                 'BaseModel'
-            )
+            ),
         ];
     }
 

--- a/src/Commands/MakeBaseModel.php
+++ b/src/Commands/MakeBaseModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeBaseModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:base-model {domain} {name=BaseModel}';
+    protected $name = 'ddd:base-model';
 
     /**
      * The console command description.
@@ -20,7 +16,21 @@ class MakeBaseModel extends DomainGeneratorCommand
      */
     protected $description = 'Generate a base domain model';
 
-    protected $type = 'BaseModel';
+    protected $type = 'Base Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                'The name of the base model',
+                'BaseModel'
+            )
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeBaseViewModel.php
+++ b/src/Commands/MakeBaseViewModel.php
@@ -28,7 +28,7 @@ class MakeBaseViewModel extends DomainGeneratorCommand
                 InputArgument::OPTIONAL,
                 'The name of the base view model',
                 'ViewModel'
-            )
+            ),
         ];
     }
 

--- a/src/Commands/MakeBaseViewModel.php
+++ b/src/Commands/MakeBaseViewModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeBaseViewModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:base-view-model {domain} {name=ViewModel}';
+    protected $name = 'ddd:base-view-model';
 
     /**
      * The console command description.
@@ -20,7 +16,21 @@ class MakeBaseViewModel extends DomainGeneratorCommand
      */
     protected $description = 'Generate a base view model';
 
-    protected $type = 'ViewModel';
+    protected $type = 'Base View Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                'The name of the base view model',
+                'ViewModel'
+            )
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeDTO.php
+++ b/src/Commands/MakeDTO.php
@@ -27,7 +27,7 @@ class MakeDTO extends DomainGeneratorCommand
                 'name',
                 InputArgument::REQUIRED,
                 'The name of the DTO',
-            )
+            ),
         ];
     }
 

--- a/src/Commands/MakeDTO.php
+++ b/src/Commands/MakeDTO.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeDTO extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:dto {domain} {name}';
+    protected $name = 'ddd:dto';
 
     /**
      * The console command description.
@@ -20,7 +16,20 @@ class MakeDTO extends DomainGeneratorCommand
      */
     protected $description = 'Generate a data transfer object';
 
-    protected $type = 'DataTransferObject';
+    protected $type = 'Data Transfer Object';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the DTO',
+            )
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:model {domain} {name}';
+    protected $name = 'ddd:model';
 
     /**
      * The console command description.
@@ -21,6 +17,19 @@ class MakeModel extends DomainGeneratorCommand
     protected $description = 'Generate a domain model';
 
     protected $type = 'Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the model',
+            )
+        ];
+    }
 
     protected function getStub()
     {
@@ -40,7 +49,7 @@ class MakeModel extends DomainGeneratorCommand
         $baseModelName = $parts->last();
         $baseModelPath = $this->getPath($baseModel);
 
-        if (! file_exists($baseModelPath)) {
+        if (!file_exists($baseModelPath)) {
             $this->warn("Base model {$baseModel} doesn't exist, generating...");
 
             $this->call(MakeBaseModel::class, [

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -27,7 +27,7 @@ class MakeModel extends DomainGeneratorCommand
                 'name',
                 InputArgument::REQUIRED,
                 'The name of the model',
-            )
+            ),
         ];
     }
 
@@ -49,7 +49,7 @@ class MakeModel extends DomainGeneratorCommand
         $baseModelName = $parts->last();
         $baseModelPath = $this->getPath($baseModel);
 
-        if (!file_exists($baseModelPath)) {
+        if (! file_exists($baseModelPath)) {
             $this->warn("Base model {$baseModel} doesn't exist, generating...");
 
             $this->call(MakeBaseModel::class, [

--- a/src/Commands/MakeValueObject.php
+++ b/src/Commands/MakeValueObject.php
@@ -27,7 +27,7 @@ class MakeValueObject extends DomainGeneratorCommand
                 'name',
                 InputArgument::REQUIRED,
                 'The name of the value object',
-            )
+            ),
         ];
     }
 

--- a/src/Commands/MakeValueObject.php
+++ b/src/Commands/MakeValueObject.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeValueObject extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:value {domain} {name}';
+    protected $name = 'ddd:value';
 
     /**
      * The console command description.
@@ -20,7 +16,20 @@ class MakeValueObject extends DomainGeneratorCommand
      */
     protected $description = 'Generate a value object';
 
-    protected $type = 'ValueObject';
+    protected $type = 'Value Object';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the value object',
+            )
+        ];
+    }
 
     protected function getRelativeDomainNamespace(): string
     {

--- a/src/Commands/MakeViewModel.php
+++ b/src/Commands/MakeViewModel.php
@@ -27,7 +27,7 @@ class MakeViewModel extends DomainGeneratorCommand
                 'name',
                 InputArgument::REQUIRED,
                 'The name of the view model',
-            )
+            ),
         ];
     }
 
@@ -49,7 +49,7 @@ class MakeViewModel extends DomainGeneratorCommand
         $baseName = $parts->last();
         $basePath = $this->getPath($baseViewModel);
 
-        if (!file_exists($basePath)) {
+        if (! file_exists($basePath)) {
             $this->warn("Base view model {$baseViewModel} doesn't exist, generating...");
 
             $this->call(MakeBaseViewModel::class, [

--- a/src/Commands/MakeViewModel.php
+++ b/src/Commands/MakeViewModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeViewModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:view-model {domain} {name}';
+    protected $name = 'ddd:view-model';
 
     /**
      * The console command description.
@@ -20,7 +16,20 @@ class MakeViewModel extends DomainGeneratorCommand
      */
     protected $description = 'Generate a view model';
 
-    protected $type = 'ViewModel';
+    protected $type = 'View Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the view model',
+            )
+        ];
+    }
 
     protected function getRelativeDomainNamespace(): string
     {
@@ -40,7 +49,7 @@ class MakeViewModel extends DomainGeneratorCommand
         $baseName = $parts->last();
         $basePath = $this->getPath($baseViewModel);
 
-        if (! file_exists($basePath)) {
+        if (!file_exists($basePath)) {
             $this->warn("Base view model {$baseViewModel} doesn't exist, generating...");
 
             $this->call(MakeBaseViewModel::class, [

--- a/tests/Generator/MakeBaseModelTest.php
+++ b/tests/Generator/MakeBaseModelTest.php
@@ -25,7 +25,7 @@ it('can generate domain base model', function () {
 });
 
 it('shows meaningful hints when prompting for missing input', function () {
-    $this->artisan("ddd:base-model")
+    $this->artisan('ddd:base-model')
         ->expectsQuestion('What is the domain?', 'Shared')
         ->assertExitCode(0);
 });

--- a/tests/Generator/MakeBaseModelTest.php
+++ b/tests/Generator/MakeBaseModelTest.php
@@ -23,3 +23,9 @@ it('can generate domain base model', function () {
 
     expect(file_exists($expectedModelPath))->toBeTrue();
 });
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan("ddd:base-model")
+        ->expectsQuestion('What is the domain?', 'Shared')
+        ->assertExitCode(0);
+});

--- a/tests/Generator/MakeBaseViewModelTest.php
+++ b/tests/Generator/MakeBaseViewModelTest.php
@@ -23,3 +23,9 @@ it('can generate base view model', function () {
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan("ddd:base-view-model")
+        ->expectsQuestion('What is the domain?', 'Shared')
+        ->assertExitCode(0);
+});

--- a/tests/Generator/MakeBaseViewModelTest.php
+++ b/tests/Generator/MakeBaseViewModelTest.php
@@ -25,7 +25,7 @@ it('can generate base view model', function () {
 });
 
 it('shows meaningful hints when prompting for missing input', function () {
-    $this->artisan("ddd:base-view-model")
+    $this->artisan('ddd:base-view-model')
         ->expectsQuestion('What is the domain?', 'Shared')
         ->assertExitCode(0);
 });

--- a/tests/Generator/MakeDataTransferObjectTest.php
+++ b/tests/Generator/MakeDataTransferObjectTest.php
@@ -50,3 +50,10 @@ it('normalizes generated data transfer object to pascal case', function ($given,
 
     expect(file_exists($expectedPath))->toBeTrue();
 })->with('makeDtoInputs');
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan("ddd:dto")
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the data transfer object be named?', 'Belt')
+        ->assertExitCode(0);
+});

--- a/tests/Generator/MakeDataTransferObjectTest.php
+++ b/tests/Generator/MakeDataTransferObjectTest.php
@@ -52,7 +52,7 @@ it('normalizes generated data transfer object to pascal case', function ($given,
 })->with('makeDtoInputs');
 
 it('shows meaningful hints when prompting for missing input', function () {
-    $this->artisan("ddd:dto")
+    $this->artisan('ddd:dto')
         ->expectsQuestion('What is the domain?', 'Utility')
         ->expectsQuestion('What should the data transfer object be named?', 'Belt')
         ->assertExitCode(0);

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -69,7 +69,7 @@ it('generates the base model if needed', function () {
     expect(file_exists($expectedModelPath))->toBeFalse();
 
     // This currently only tests for the default base model
-    $expectedBaseModelPath = base_path(config('ddd.paths.domains') . '/Shared/Models/BaseModel.php');
+    $expectedBaseModelPath = base_path(config('ddd.paths.domains').'/Shared/Models/BaseModel.php');
 
     if (file_exists($expectedBaseModelPath)) {
         unlink($expectedBaseModelPath);
@@ -87,7 +87,7 @@ it('generates the base model if needed', function () {
 });
 
 it('shows meaningful hints when prompting for missing input', function () {
-    $this->artisan("ddd:model")
+    $this->artisan('ddd:model')
         ->expectsQuestion('What is the domain?', 'Utility')
         ->expectsQuestion('What should the model be named?', 'Belt')
         ->assertExitCode(0);

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -69,7 +69,7 @@ it('generates the base model if needed', function () {
     expect(file_exists($expectedModelPath))->toBeFalse();
 
     // This currently only tests for the default base model
-    $expectedBaseModelPath = base_path(config('ddd.paths.domains').'/Shared/Models/BaseModel.php');
+    $expectedBaseModelPath = base_path(config('ddd.paths.domains') . '/Shared/Models/BaseModel.php');
 
     if (file_exists($expectedBaseModelPath)) {
         unlink($expectedBaseModelPath);
@@ -84,4 +84,11 @@ it('generates the base model if needed', function () {
     Artisan::call("ddd:model {$domain} {$modelName}");
 
     expect(file_exists($expectedBaseModelPath))->toBeTrue();
+});
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan("ddd:model")
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the model be named?', 'Belt')
+        ->assertExitCode(0);
 });

--- a/tests/Generator/MakeValueObjectTest.php
+++ b/tests/Generator/MakeValueObjectTest.php
@@ -58,7 +58,7 @@ it('normalizes generated value object to pascal case', function ($given, $normal
 ]);
 
 it('shows meaningful hints when prompting for missing input', function () {
-    $this->artisan("ddd:value")
+    $this->artisan('ddd:value')
         ->expectsQuestion('What is the domain?', 'Utility')
         ->expectsQuestion('What should the value object be named?', 'Belt')
         ->assertExitCode(0);

--- a/tests/Generator/MakeValueObjectTest.php
+++ b/tests/Generator/MakeValueObjectTest.php
@@ -56,3 +56,10 @@ it('normalizes generated value object to pascal case', function ($given, $normal
     'LargeNumber' => ['LargeNumber', 'LargeNumber'],
     'large-number' => ['large-number', 'LargeNumber'],
 ]);
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan("ddd:value")
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the value object be named?', 'Belt')
+        ->assertExitCode(0);
+});

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -69,7 +69,7 @@ it('generates the base view model if needed', function () {
     expect(file_exists($expectedPath))->toBeFalse();
 
     // This currently only tests for the default base model
-    $expectedBaseViewModelPath = base_path(config('ddd.paths.domains') . '/Shared/ViewModels/ViewModel.php');
+    $expectedBaseViewModelPath = base_path(config('ddd.paths.domains').'/Shared/ViewModels/ViewModel.php');
 
     if (file_exists($expectedBaseViewModelPath)) {
         unlink($expectedBaseViewModelPath);
@@ -83,7 +83,7 @@ it('generates the base view model if needed', function () {
 });
 
 it('shows meaningful hints when prompting for missing input', function () {
-    $this->artisan("ddd:view-model")
+    $this->artisan('ddd:view-model')
         ->expectsQuestion('What is the domain?', 'Utility')
         ->expectsQuestion('What should the view model be named?', 'Belt')
         ->assertExitCode(0);

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -69,7 +69,7 @@ it('generates the base view model if needed', function () {
     expect(file_exists($expectedPath))->toBeFalse();
 
     // This currently only tests for the default base model
-    $expectedBaseViewModelPath = base_path(config('ddd.paths.domains').'/Shared/ViewModels/ViewModel.php');
+    $expectedBaseViewModelPath = base_path(config('ddd.paths.domains') . '/Shared/ViewModels/ViewModel.php');
 
     if (file_exists($expectedBaseViewModelPath)) {
         unlink($expectedBaseViewModelPath);
@@ -80,4 +80,11 @@ it('generates the base view model if needed', function () {
     Artisan::call("ddd:view-model {$domain} {$className}");
 
     expect(file_exists($expectedBaseViewModelPath))->toBeTrue();
+});
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan("ddd:view-model")
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the view model be named?', 'Belt')
+        ->assertExitCode(0);
 });


### PR DESCRIPTION
### Changed
- Update argument definitions across generator commands so that it plays nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.