### PR TITLE
0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
-## [Unversioned]
+## [0.4.0]
 ### Changed
 - Update argument definitions across generator commands so that it plays nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.
+
+### Fixed
+- Ensure the configured domain path and namespace is respected by `ddd:base-model` and `ddd:base-view-model`.
 
 ## [0.3.0] - 2023-03-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
-## [0.4.0]
+## [0.4.0] - 2023-05-08
 ### Changed
 - Update argument definitions across generator commands so that it plays nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [Unversioned]
+### Changed
+- Update argument definitions across generator commands so that it plays nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.
+
 ## [0.3.0] - 2023-03-23
 ### Added
 - Increase test coverage to ensure expected namespaces are present in generated objects.

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -4,9 +4,21 @@ namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
 
 abstract class DomainGeneratorCommand extends GeneratorCommand
 {
+    protected function getArguments()
+    {
+        return [
+            new InputArgument(
+                'domain',
+                InputArgument::REQUIRED,
+                'The domain'
+            ),
+        ];
+    }
+
     protected function rootNamespace()
     {
         return str($this->getDomainBasePath())

--- a/src/Commands/MakeBaseModel.php
+++ b/src/Commands/MakeBaseModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeBaseModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:base-model {domain} {name=BaseModel}';
+    protected $name = 'ddd:base-model';
 
     /**
      * The console command description.
@@ -20,7 +16,21 @@ class MakeBaseModel extends DomainGeneratorCommand
      */
     protected $description = 'Generate a base domain model';
 
-    protected $type = 'BaseModel';
+    protected $type = 'Base Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                'The name of the base model',
+                'BaseModel'
+            ),
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeBaseViewModel.php
+++ b/src/Commands/MakeBaseViewModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeBaseViewModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:base-view-model {domain} {name=ViewModel}';
+    protected $name = 'ddd:base-view-model';
 
     /**
      * The console command description.
@@ -20,7 +16,21 @@ class MakeBaseViewModel extends DomainGeneratorCommand
      */
     protected $description = 'Generate a base view model';
 
-    protected $type = 'ViewModel';
+    protected $type = 'Base View Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                'The name of the base view model',
+                'ViewModel'
+            ),
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeDTO.php
+++ b/src/Commands/MakeDTO.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeDTO extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:dto {domain} {name}';
+    protected $name = 'ddd:dto';
 
     /**
      * The console command description.
@@ -20,7 +16,20 @@ class MakeDTO extends DomainGeneratorCommand
      */
     protected $description = 'Generate a data transfer object';
 
-    protected $type = 'DataTransferObject';
+    protected $type = 'Data Transfer Object';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the DTO',
+            ),
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:model {domain} {name}';
+    protected $name = 'ddd:model';
 
     /**
      * The console command description.
@@ -21,6 +17,19 @@ class MakeModel extends DomainGeneratorCommand
     protected $description = 'Generate a domain model';
 
     protected $type = 'Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the model',
+            ),
+        ];
+    }
 
     protected function getStub()
     {

--- a/src/Commands/MakeValueObject.php
+++ b/src/Commands/MakeValueObject.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeValueObject extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:value {domain} {name}';
+    protected $name = 'ddd:value';
 
     /**
      * The console command description.
@@ -20,7 +16,20 @@ class MakeValueObject extends DomainGeneratorCommand
      */
     protected $description = 'Generate a value object';
 
-    protected $type = 'ValueObject';
+    protected $type = 'Value Object';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the value object',
+            ),
+        ];
+    }
 
     protected function getRelativeDomainNamespace(): string
     {

--- a/src/Commands/MakeViewModel.php
+++ b/src/Commands/MakeViewModel.php
@@ -3,15 +3,11 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class MakeViewModel extends DomainGeneratorCommand
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ddd:view-model {domain} {name}';
+    protected $name = 'ddd:view-model';
 
     /**
      * The console command description.
@@ -20,7 +16,20 @@ class MakeViewModel extends DomainGeneratorCommand
      */
     protected $description = 'Generate a view model';
 
-    protected $type = 'ViewModel';
+    protected $type = 'View Model';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the view model',
+            ),
+        ];
+    }
 
     protected function getRelativeDomainNamespace(): string
     {

--- a/stubs/base-model.php.stub
+++ b/stubs/base-model.php.stub
@@ -1,11 +1,11 @@
 <?php
 
-namespace Domains\Shared\Models;
+namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-abstract class BaseModel extends Model
+abstract class {{ class }} extends Model
 {
     use HasFactory;
 

--- a/stubs/base-view-model.php.stub
+++ b/stubs/base-view-model.php.stub
@@ -1,13 +1,13 @@
 <?php
 
-namespace Domains\Shared\ViewModels;
+namespace {{ namespace }};
 
 use Illuminate\Contracts\Support\Arrayable;
 use Reflection;
 use ReflectionClass;
 use ReflectionMethod;
 
-abstract class ViewModel implements Arrayable
+abstract class {{ class }} implements Arrayable
 {
     protected $hidden = [];
 

--- a/stubs/model.php.stub
+++ b/stubs/model.php.stub
@@ -10,11 +10,4 @@ class {{ class }} extends BaseModel
     use SoftDeletes;
 
     protected $casts = [];
-
-    public static function metadata()
-    {
-        return [
-            // ...
-        ];
-    }
 }

--- a/tests/Generator/MakeBaseModelTest.php
+++ b/tests/Generator/MakeBaseModelTest.php
@@ -23,3 +23,9 @@ it('can generate domain base model', function () {
 
     expect(file_exists($expectedModelPath))->toBeTrue();
 });
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:base-model')
+        ->expectsQuestion('What is the domain?', 'Shared')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();

--- a/tests/Generator/MakeBaseModelTest.php
+++ b/tests/Generator/MakeBaseModelTest.php
@@ -1,28 +1,39 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
 
-it('can generate domain base model', function () {
+it('can generate domain base model', function ($domainPath, $domainRoot) {
+    Config::set('ddd.paths.domains', $domainPath);
+
     $modelName = 'BaseModel';
     $domain = 'Shared';
 
-    $expectedModelPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+    $expectedPath = base_path(implode('/', [
+        $domainPath,
         $domain,
         config('ddd.namespaces.models'),
         "{$modelName}.php",
     ]));
 
-    if (file_exists($expectedModelPath)) {
-        unlink($expectedModelPath);
+    if (file_exists($expectedPath)) {
+        unlink($expectedPath);
     }
 
-    expect(file_exists($expectedModelPath))->toBeFalse();
+    expect(file_exists($expectedPath))->toBeFalse();
 
     Artisan::call("ddd:base-model {$domain} {$modelName}");
 
-    expect(file_exists($expectedModelPath))->toBeTrue();
-});
+    expect(file_exists($expectedPath))->toBeTrue();
+
+    $expectedNamespace = implode('\\', [
+        $domainRoot,
+        $domain,
+        config('ddd.namespaces.models'),
+    ]);
+
+    expect(file_get_contents($expectedPath))->toContain("namespace {$expectedNamespace};");
+})->with('domainPaths');
 
 it('shows meaningful hints when prompting for missing input', function () {
     $this->artisan('ddd:base-model')

--- a/tests/Generator/MakeBaseViewModelTest.php
+++ b/tests/Generator/MakeBaseViewModelTest.php
@@ -23,3 +23,9 @@ it('can generate base view model', function () {
 
     expect(file_exists($expectedPath))->toBeTrue();
 });
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:base-view-model')
+        ->expectsQuestion('What is the domain?', 'Shared')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();

--- a/tests/Generator/MakeBaseViewModelTest.php
+++ b/tests/Generator/MakeBaseViewModelTest.php
@@ -1,13 +1,16 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
 
-it('can generate base view model', function () {
+it('can generate base view model', function ($domainPath, $domainRoot) {
+    Config::set('ddd.paths.domains', $domainPath);
+
     $className = 'ViewModel';
     $domain = 'Shared';
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        $domainPath,
         $domain,
         config('ddd.namespaces.view_models'),
         "{$className}.php",
@@ -22,7 +25,15 @@ it('can generate base view model', function () {
     Artisan::call("ddd:base-view-model {$domain} {$className}");
 
     expect(file_exists($expectedPath))->toBeTrue();
-});
+
+    $expectedNamespace = implode('\\', [
+        $domainRoot,
+        $domain,
+        config('ddd.namespaces.view_models'),
+    ]);
+
+    expect(file_get_contents($expectedPath))->toContain("namespace {$expectedNamespace};");
+})->with('domainPaths');
 
 it('shows meaningful hints when prompting for missing input', function () {
     $this->artisan('ddd:base-view-model')

--- a/tests/Generator/MakeDataTransferObjectTest.php
+++ b/tests/Generator/MakeDataTransferObjectTest.php
@@ -50,3 +50,10 @@ it('normalizes generated data transfer object to pascal case', function ($given,
 
     expect(file_exists($expectedPath))->toBeTrue();
 })->with('makeDtoInputs');
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:dto')
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the data transfer object be named?', 'Belt')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -85,3 +85,10 @@ it('generates the base model if needed', function () {
 
     expect(file_exists($expectedBaseModelPath))->toBeTrue();
 });
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:model')
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the model be named?', 'Belt')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();

--- a/tests/Generator/MakeValueObjectTest.php
+++ b/tests/Generator/MakeValueObjectTest.php
@@ -56,3 +56,10 @@ it('normalizes generated value object to pascal case', function ($given, $normal
     'LargeNumber' => ['LargeNumber', 'LargeNumber'],
     'large-number' => ['large-number', 'LargeNumber'],
 ]);
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:value')
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the value object be named?', 'Belt')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -81,3 +81,10 @@ it('generates the base view model if needed', function () {
 
     expect(file_exists($expectedBaseViewModelPath))->toBeTrue();
 });
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:view-model')
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the view model be named?', 'Belt')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,3 +3,17 @@
 use Lunarstorm\LaravelDDD\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
+
+function skipOnLaravelVersionsBelow($minimumVersion)
+{
+    $version = app()->version();
+
+    if (version_compare($version, $minimumVersion, '<')) {
+        test()->markTestSkipped("Only relevant from Laravel {$minimumVersion} onwards (Current version: {$version}).");
+    }
+}
+
+function ifSupportsPromptForMissingInput()
+{
+    return skipOnLaravelVersionsBelow('9.49.0');
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,9 @@ class TestCase extends Orchestra
             fn (string $modelName) => 'Lunarstorm\\LaravelDDD\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
 
+        File::deleteDirectory(resource_path('stubs/ddd'));
+        File::deleteDirectory(resource_path('config/ddd'));
+
         $this->beforeApplicationDestroyed(function () {
             File::cleanDirectory(app_path());
             File::deleteDirectory(base_path('Custom'));


### PR DESCRIPTION
### Changed
- Update argument definitions across generator commands so that it plays nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.

### Fixed
- Ensure the configured domain path and namespace is respected by `ddd:base-model` and `ddd:base-view-model`.