### PR TITLE
Implement `ddd:action` generator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [0.5.0] - 2023-06-14
+### Added
+- Ability to generate actions (`ddd:action`), which by default generates an action class based on the `lorisleiva/laravel-actions` package.
+
+### Changed
+- Minor cleanups and updates to the default `ddd.php` config file.
+- Update stubs to be less opinionated where possible.
+
 ## [0.4.0] - 2023-05-08
 ### Changed
 - Update argument definitions across generator commands to play nicely with `PromptsForMissingInput` behaviour introduced in Laravel v9.49.0.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ php artisan ddd:value {domain} {name}
 
 # Generates a view model
 php artisan ddd:view-model {domain} {name}
+
+# Generates an action
+php artisan ddd:action {domain} {name}
 ```
 Examples:
 ```bash
@@ -45,6 +48,7 @@ php artisan ddd:model Invoicing LineItem # Domain/Invoicing/Models/LineItem
 php artisan ddd:dto Invoicing LinePayload # Domain/Invoicing/Data/LinePayload
 php artisan ddd:value Shared Percentage # Domain/Shared/ValueObjects/Percentage
 php artisan ddd:view-model Invoicing ShowInvoiceViewModel # Domain/Invoicing/ViewModels/ShowInvoiceViewModel
+php artisan ddd:action Invoicing SendInvoiceToCustomer # Domain/Invoicing/Actions/SendInvoiceToCustomer
 ```
 
 This package ships with opinionated (but sensible) configuration defaults. If you need to customize, you may do so by publishing the config file and generator stubs as needed:
@@ -74,18 +78,6 @@ return [
         // Path to the Domain layer.
         //
         'domains' => 'src/Domain',
-
-        //
-        // Path to modules in the application layer. This is an extension of
-        // domain driven design applied to the application layer, bundling
-        // application objects (Controllers, Resources, Requests) in a
-        // more modular fashion.
-        //
-        // e.g., app/Modules/Invoicing/Controllers/*
-        //       app/Modules/Invoicing/Resources/*
-        //       app/Modules/Invoicing/Requests/*
-        //
-        'modules' => 'app/Modules',
     ],
 
     /*
@@ -123,6 +115,11 @@ return [
         // Value Objects
         //
         'value_objects' => 'ValueObjects',
+
+        //
+        // Actions
+        //
+        'actions' => 'Actions',
     ],
 
     /*
@@ -161,6 +158,17 @@ return [
     |
     */
     'base_view_model' => 'Domain\Shared\ViewModels\ViewModel',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base Action
+    |--------------------------------------------------------------------------
+    |
+    | This base class which generated action objects should extend. By
+    | default, generated actions do not extend anything.
+    |
+    */
+    'base_action' => null,
 ];
 ```
 

--- a/config/ddd.php
+++ b/config/ddd.php
@@ -17,18 +17,6 @@ return [
         // Path to the Domain layer.
         //
         'domains' => 'src/Domain',
-
-        //
-        // Path to modules in the application layer. This is an extension of
-        // domain driven design applied to the application layer, bundling
-        // application objects (Controllers, Resources, Requests) in a
-        // more modular fashion.
-        //
-        // e.g., app/Modules/Invoicing/Controllers/*
-        //       app/Modules/Invoicing/Resources/*
-        //       app/Modules/Invoicing/Requests/*
-        //
-        'modules' => 'app/Modules',
     ],
 
     /*
@@ -66,6 +54,11 @@ return [
         // Value Objects
         //
         'value_objects' => 'ValueObjects',
+
+        //
+        // Actions
+        //
+        'actions' => 'Actions',
     ],
 
     /*
@@ -104,4 +97,15 @@ return [
     |
     */
     'base_view_model' => 'Domain\Shared\ViewModels\ViewModel',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Base Action
+    |--------------------------------------------------------------------------
+    |
+    | This base class which generated action objects should extend. By
+    | default, generated actions do not extend anything.
+    |
+    */
+    'base_action' => null,
 ];

--- a/config/ddd.php
+++ b/config/ddd.php
@@ -67,7 +67,7 @@ return [
     | Base Model
     |--------------------------------------------------------------------------
     |
-    | This base model which generated domain models should extend. By default,
+    | The base class which generated domain models should extend. By default,
     | generated domain models will extend `Domain\Shared\Models\BaseModel`,
     | which will be created if it doesn't already exist.
     |
@@ -79,7 +79,7 @@ return [
     | Base DTO
     |--------------------------------------------------------------------------
     |
-    | This base model which generated data transfer objects should extend. By
+    | The base class which generated data transfer objects should extend. By
     | default, generated DTOs will extend `Spatie\LaravelData\Data` from
     | Spatie's Laravel-data package, a highly recommended data object
     | package to work with.
@@ -92,7 +92,7 @@ return [
     | Base ViewModel
     |--------------------------------------------------------------------------
     |
-    | This base view model which generated view models should extend. By default,
+    | The base class which generated view models should extend. By default,
     | generated domain models will extend `Domain\Shared\ViewModels\BaseViewModel`,
     | which will be created if it doesn't already exist.
     |
@@ -104,8 +104,9 @@ return [
     | Base Action
     |--------------------------------------------------------------------------
     |
-    | This base class which generated action objects should extend. By
-    | default, generated actions do not extend anything.
+    | The base class which generated action objects should extend. By default,
+    | generated actions are based on the `lorisleiva/laravel-actions` package
+    | and do not extend anything.
     |
     */
     'base_action' => null,

--- a/config/ddd.php
+++ b/config/ddd.php
@@ -32,6 +32,7 @@ return [
     |       Domain/Invoicing/Data/*
     |       Domain/Invoicing/ViewModels/*
     |       Domain/Invoicing/ValueObjects/*
+    |       Domain/Invoicing/Actions/*
     |
     */
     'namespaces' => [

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -76,4 +76,9 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
             ? $publishedPath
             : __DIR__.DIRECTORY_SEPARATOR.'../../stubs'.DIRECTORY_SEPARATOR.$path;
     }
+
+    protected function fillPlaceholder($stub, $placeholder, $value)
+    {
+        return str_replace(["{{$placeholder}}", "{{ $placeholder }}"], $value, $stub);
+    }
 }

--- a/src/Commands/MakeAction.php
+++ b/src/Commands/MakeAction.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+
+class MakeAction extends DomainGeneratorCommand
+{
+    protected $name = 'ddd:action';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate an action';
+
+    protected $type = 'Action';
+
+    protected function getArguments()
+    {
+        return [
+            ...parent::getArguments(),
+
+            new InputArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'The name of the Action',
+            ),
+        ];
+    }
+
+    protected function getStub()
+    {
+        return $this->resolveStubPath('action.php.stub');
+    }
+
+    protected function getRelativeDomainNamespace(): string
+    {
+        return config('ddd.namespaces.actions', 'Actions');
+    }
+
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $baseClass = config('ddd.base_action');
+        $extends = filled($baseClass) ? " extends {$baseClass}" : '';
+
+        return $this->fillPlaceholder($stub, 'extends', $extends);
+    }
+}

--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Lunarstorm\LaravelDDD;
 
 use Lunarstorm\LaravelDDD\Commands\InstallCommand;
+use Lunarstorm\LaravelDDD\Commands\MakeAction;
 use Lunarstorm\LaravelDDD\Commands\MakeBaseModel;
 use Lunarstorm\LaravelDDD\Commands\MakeBaseViewModel;
 use Lunarstorm\LaravelDDD\Commands\MakeDTO;
@@ -32,6 +33,7 @@ class LaravelDDDServiceProvider extends PackageServiceProvider
                 MakeValueObject::class,
                 MakeViewModel::class,
                 MakeBaseViewModel::class,
+                MakeAction::class,
             ]);
     }
 

--- a/stubs/action.php.stub
+++ b/stubs/action.php.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace {{ namespace }};
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class {{ class }}{{ extends }}
+{
+    use AsAction;
+
+    public function handle() {
+        // ...
+    }
+}

--- a/stubs/dto.php.stub
+++ b/stubs/dto.php.stub
@@ -6,8 +6,7 @@ use Spatie\LaravelData\Data;
 
 class {{ class }} extends Data
 {
-    public function __construct(
+    public function __construct() {
         // ...
-    ) {
     }
 }

--- a/stubs/value-object.php.stub
+++ b/stubs/value-object.php.stub
@@ -4,9 +4,7 @@ namespace {{ namespace }};
 
 class {{ class }}
 {
-    public function __construct(
-        public readonly $value = null
-    ) {
+    public function __construct() {
         // ...
     }
 }

--- a/stubs/view-model.php.stub
+++ b/stubs/view-model.php.stub
@@ -7,5 +7,6 @@ use {{ rootNamespace }}\Shared\ViewModels\ViewModel;
 class {{ class }} extends ViewModel
 {
     public function __construct() {
+        // ...
     }
 }

--- a/tests/Datasets/Actions.php
+++ b/tests/Datasets/Actions.php
@@ -1,0 +1,12 @@
+<?php
+
+dataset('makeActionInputs', [
+    'GenerateInvoice' => ['GenerateInvoice', 'GenerateInvoice'],
+    'generateInvoice' => ['generateInvoice', 'GenerateInvoice'],
+    'generate-invoice' => ['generate-invoice', 'GenerateInvoice'],
+    'PublishPendingPosts' => ['PublishPendingPosts', 'PublishPendingPosts'],
+    'publishPendingPosts' => ['publishPendingPosts', 'PublishPendingPosts'],
+    'publish-pending-posts' => ['publish-pending-posts', 'PublishPendingPosts'],
+    'reboot' => ['reboot', 'Reboot'],
+    'Reboot' => ['Reboot', 'Reboot'],
+]);

--- a/tests/Generator/MakeActionTest.php
+++ b/tests/Generator/MakeActionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+it('can generate action objects', function ($domainPath, $domainRoot) {
+    Config::set('ddd.paths.domains', $domainPath);
+
+    $name = Str::studly(fake()->word());
+    $domain = Str::studly(fake()->word());
+
+    $expectedPath = base_path(implode('/', [
+        $domainPath,
+        $domain,
+        config('ddd.namespaces.actions'),
+        "{$name}.php",
+    ]));
+
+    if (file_exists($expectedPath)) {
+        unlink($expectedPath);
+    }
+
+    expect(file_exists($expectedPath))->toBeFalse();
+
+    Artisan::call("ddd:action {$domain} {$name}");
+
+    expect(file_exists($expectedPath))->toBeTrue();
+
+    $expectedNamespace = implode('\\', [
+        $domainRoot,
+        $domain,
+        config('ddd.namespaces.actions'),
+    ]);
+
+    expect(file_get_contents($expectedPath))->toContain("namespace {$expectedNamespace};");
+})->with('domainPaths');
+
+it('normalizes generated action object to pascal case', function ($given, $normalized) {
+    $domain = Str::studly(fake()->word());
+
+    $expectedPath = base_path(implode('/', [
+        config('ddd.paths.domains'),
+        $domain,
+        config('ddd.namespaces.actions'),
+        "{$normalized}.php",
+    ]));
+
+    Artisan::call("ddd:action {$domain} {$given}");
+
+    expect(file_exists($expectedPath))->toBeTrue();
+})->with('makeActionInputs');
+
+it('shows meaningful hints when prompting for missing input', function () {
+    $this->artisan('ddd:action')
+        ->expectsQuestion('What is the domain?', 'Utility')
+        ->expectsQuestion('What should the action be named?', 'DoThatThing')
+        ->assertExitCode(0);
+})->ifSupportsPromptForMissingInput();
+
+it('extends a base action if specified in config', function ($baseAction) {
+    Config::set('ddd.base_action', $baseAction);
+
+    $name = Str::studly(fake()->word());
+    $domain = Str::studly(fake()->word());
+
+    $expectedPath = base_path(implode('/', [
+        config('ddd.paths.domains'),
+        $domain,
+        config('ddd.namespaces.actions'),
+        "{$name}.php",
+    ]));
+
+    if (file_exists($expectedPath)) {
+        unlink($expectedPath);
+    }
+
+    Artisan::call("ddd:action {$domain} {$name}");
+
+    expect(file_exists($expectedPath))->toBeTrue();
+
+    expect(file_get_contents($expectedPath))->toContain("class {$name} extends {$baseAction}\n{");
+})->with([
+    'BaseAction' => 'BaseAction',
+    'Base\Action' => 'Base\Action',
+]);
+
+it('does not extend a base action if not specified in config', function () {
+    Config::set('ddd.base_action', null);
+
+    $name = Str::studly(fake()->word());
+    $domain = Str::studly(fake()->word());
+
+    $expectedPath = base_path(implode('/', [
+        config('ddd.paths.domains'),
+        $domain,
+        config('ddd.namespaces.actions'),
+        "{$name}.php",
+    ]));
+
+    if (file_exists($expectedPath)) {
+        unlink($expectedPath);
+    }
+
+    Artisan::call("ddd:action {$domain} {$name}");
+
+    expect(file_exists($expectedPath))->toBeTrue();
+    expect(file_get_contents($expectedPath))->toContain("class {$name}\n{");
+});

--- a/tests/Generator/MakeActionTest.php
+++ b/tests/Generator/MakeActionTest.php
@@ -105,5 +105,5 @@ it('does not extend a base action if not specified in config', function () {
     Artisan::call("ddd:action {$domain} {$name}");
 
     expect(file_exists($expectedPath))->toBeTrue();
-    expect(file_get_contents($expectedPath))->toContain("class {$name}".PHP_EOL."{");
+    expect(file_get_contents($expectedPath))->toContain("class {$name}".PHP_EOL.'{');
 });

--- a/tests/Generator/MakeActionTest.php
+++ b/tests/Generator/MakeActionTest.php
@@ -79,7 +79,7 @@ it('extends a base action if specified in config', function ($baseAction) {
 
     expect(file_exists($expectedPath))->toBeTrue();
 
-    expect(file_get_contents($expectedPath))->toContain("class {$name} extends {$baseAction}\n{");
+    expect(file_get_contents($expectedPath))->toContain("class {$name} extends {$baseAction}".PHP_EOL.'{');
 })->with([
     'BaseAction' => 'BaseAction',
     'Base\Action' => 'Base\Action',

--- a/tests/Generator/MakeActionTest.php
+++ b/tests/Generator/MakeActionTest.php
@@ -105,5 +105,5 @@ it('does not extend a base action if not specified in config', function () {
     Artisan::call("ddd:action {$domain} {$name}");
 
     expect(file_exists($expectedPath))->toBeTrue();
-    expect(file_get_contents($expectedPath))->toContain("class {$name}\n{");
+    expect(file_get_contents($expectedPath))->toContain("class {$name}".PHP_EOL."{");
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,8 @@ class TestCase extends Orchestra
     {
         parent::setUp();
 
+        $this->cleanFilesAndFolders();
+
         $composerFile = base_path('composer.json');
         $data = json_decode(file_get_contents($composerFile), true);
 
@@ -29,14 +31,7 @@ class TestCase extends Orchestra
             fn (string $modelName) => 'Lunarstorm\\LaravelDDD\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
 
-        File::deleteDirectory(resource_path('stubs/ddd'));
-        File::deleteDirectory(resource_path('config/ddd'));
-
-        $this->beforeApplicationDestroyed(function () {
-            File::cleanDirectory(app_path());
-            File::deleteDirectory(base_path('Custom'));
-            File::deleteDirectory(base_path('src/Domains'));
-        });
+        $this->beforeApplicationDestroyed(fn () => $this->cleanFilesAndFolders());
     }
 
     protected function getPackageProviders($app)
@@ -59,5 +54,16 @@ class TestCase extends Orchestra
             ->setTimeout(null)
             ->run(function ($type, $output) {
             });
+    }
+
+    protected function cleanFilesAndFolders()
+    {
+        File::delete(base_path('config/ddd.php'));
+
+        File::cleanDirectory(app_path());
+
+        File::deleteDirectory(resource_path('stubs/ddd'));
+        File::deleteDirectory(base_path('Custom'));
+        File::deleteDirectory(base_path('src/Domains'));
     }
 }


### PR DESCRIPTION
Introduces support for generating actions. Default stub follows the template based on the `lorisleiva/laravel-actions` package. Optionally, a custom base action class can be configured via `ddd.base_action` if needed.

### Added
- Ability to generate actions (`ddd:action`), which by default generates an action class based on the `lorisleiva/laravel-actions` package.

### Changed
- Minor cleanups and updates to the default `ddd.php` config file.
- Update stubs to be less opinionated where possible.