### PR TITLE
Normalize factory class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to `laravel-ddd` will be documented in this file.
 
 ## [0.6.1] - 2023-08-14
 ### Fixed
-- Ensure that generated domain factories set the `protected $model` property.
+- Ensure generated domain factories set the `protected $model` property.
+- Ensure generated factory classes are always suffixed by `Factory`.
 
 ## [0.6.0] - 2023-08-14
 ### Added

--- a/src/Commands/MakeFactory.php
+++ b/src/Commands/MakeFactory.php
@@ -63,6 +63,10 @@ class MakeFactory extends DomainGeneratorCommand
 
     protected function getPath($name)
     {
+        if (! str_ends_with($name, 'Factory')) {
+            $name .= 'Factory';
+        }
+
         $name = str($name)
             ->replaceFirst($this->rootNamespace(), '')
             ->replace('\\', '/')
@@ -71,6 +75,15 @@ class MakeFactory extends DomainGeneratorCommand
             ->toString();
 
         return base_path('database/factories/'.$name);
+    }
+
+    protected function getFactoryName()
+    {
+        $name = $this->getNameInput();
+
+        return str_ends_with($name, 'Factory')
+            ? substr($name, 0, -7)
+            : $name;
     }
 
     protected function preparePlaceholders(): array
@@ -86,6 +99,7 @@ class MakeFactory extends DomainGeneratorCommand
         return [
             'namespacedModel' => $namespacedModel,
             'model' => class_basename($namespacedModel),
+            'factory' => $this->getFactoryName(),
         ];
     }
 

--- a/stubs/factory.php.stub
+++ b/stubs/factory.php.stub
@@ -5,7 +5,7 @@ namespace {{ namespace }};
 use Illuminate\Database\Eloquent\Factories\Factory;
 use {{ namespacedModel }};
 
-class {{ class }} extends Factory
+class {{ factory }}Factory extends Factory
 {
     protected $model = {{ model }}::class;
 

--- a/tests/Generator/MakeFactoryTest.php
+++ b/tests/Generator/MakeFactoryTest.php
@@ -33,7 +33,7 @@ it('can generate domain factories', function ($domainPath, $domainRoot) {
 
     expect(file_exists($expectedFactoryPath))->toBeFalse();
 
-    Artisan::call("ddd:factory {$domain} {$factoryName}");
+    Artisan::call("ddd:factory {$domain} {$modelName}");
 
     expect(Artisan::output())->when(
         Feature::IncludeFilepathInGeneratorCommandOutput->exists(),
@@ -55,5 +55,8 @@ it('can generate domain factories', function ($domainPath, $domainRoot) {
     expect($contents)
         ->toContain("namespace {$expectedNamespace};")
         ->toContain("use {$namespacedModel};")
+        ->toContain("class {$factoryName} extends Factory")
         ->toContain("protected \$model = {$modelName}::class;");
 })->with('domainPaths');
+
+it('enforces generated factory classes have Factory suffix')->todo();

--- a/tests/Generator/MakeFactoryTest.php
+++ b/tests/Generator/MakeFactoryTest.php
@@ -59,4 +59,4 @@ it('can generate domain factories', function ($domainPath, $domainRoot) {
         ->toContain("protected \$model = {$modelName}::class;");
 })->with('domainPaths');
 
-it('enforces generated factory classes have Factory suffix')->todo();
+it('normalizes factory classes with Factory suffix')->markTestIncomplete();


### PR DESCRIPTION
Conform to laravel's factory generation behaviour and ensure the generated classes always have a `Factory` suffix.

`ddd:factory Invoicing InvoiceFactory` and `ddd:factory Invoicing Invoice` should both generate an `InvoiceFactory` class.