### PR TITLE
feat: Add support for subdomains in newFactory method (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to `laravel-ddd` will be documented in this file.
 
 ## [Unversioned]
 ### Added
-- Formally support for subdomains (nested domains) when generating domain objects. For example, to generate a model under `Domain\Reporting\Internal`, the domain argument can be specified in any of the following ways:
-    - `ddd:model Reporting\Internal InvoiceReport`
+- Formal support for subdomains (nested domains). For example, to generate model `Domain\Reporting\Internal\Models\InvoiceReport`, the domain argument can be specified in any of the following ways:
+    - `ddd:model Reporting\\Internal InvoiceReport`
     - `ddd:model Reporting/Internal InvoiceReport`
     - `ddd:model Reporting.Internal InvoiceReport`
 - Implement abstract `Lunarstorm\LaravelDDD\Factories\DomainFactory` extension of `Illuminate\Database\Eloquent\Factories\Factory`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [Unversioned]
+### Added
+- Formally support for subdomains (nested domains) when generating domain objects. For example, to generate a model under `Domain\Reporting\Internal`, the domain argument can be specified in any of the following ways:
+    - `ddd:model Reporting\Internal InvoiceReport`
+    - `ddd:model Reporting/Internal InvoiceReport`
+    - `ddd:model Reporting.Internal InvoiceReport`
+- Implement abstract `Lunarstorm\LaravelDDD\Factories\DomainFactory` extension of `Illuminate\Database\Eloquent\Factories\Factory`:
+    - Implements `DomainFactory::resolveFactoryName()` to resolve the corresponding factory for a domain model.
+    - Will resolve the correct factory if the model belongs to a subdomain; `Domain\Reporting\Internal\Models\InvoiceReport` will correctly resolve to `Database\Factories\Reporting\Internal\InvoiceReportFactory`.
+
+### Changed
+- Default base model implementation in `base-model.php.stub` now uses using `DomainFactory::factoryForModel()` inside the `newFactory` method to resolve the model factory.
+
 ## [0.6.1] - 2023-08-14
 ### Fixed
 - Ensure generated domain factories set the `protected $model` property.

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,10 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Lunarstorm\\LaravelDDD\\Tests\\": "tests"
+            "Lunarstorm\\LaravelDDD\\Tests\\": "tests",
+            "App\\": "vendor/orchestra/testbench-core/laravel/app/",
+            "Database\\Factories\\": "vendor/orchestra/testbench-core/laravel/database/factories/",
+            "Domain\\": "vendor/orchestra/testbench-core/laravel/src/Domain/"
         }
     },
     "scripts": {
@@ -50,7 +53,8 @@
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "lint": "vendor/bin/pint"
     },
     "config": {
         "sort-packages": true,

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -50,6 +50,7 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
     {
         return str($this->getDomainInput())
             ->trim()
+            ->replace(['.', '/'], '\\')
             ->studly()
             ->toString();
     }

--- a/src/Commands/MakeFactory.php
+++ b/src/Commands/MakeFactory.php
@@ -92,14 +92,17 @@ class MakeFactory extends DomainGeneratorCommand
 
         $name = $this->getNameInput();
 
-        $namespacedModel = $this->option('model')
-            ? $domain->namespacedModel($this->option('model'))
-            : $domain->namespacedModel($this->guessModelName($name));
+        $modelName = $this->option('model') ?: $this->guessModelName($name);
+
+        $domainModel = $domain->model($modelName);
+
+        $domainFactory = $domain->factory($name);
 
         return [
-            'namespacedModel' => $namespacedModel,
-            'model' => class_basename($namespacedModel),
+            'namespacedModel' => $domainModel->fqn,
+            'model' => class_basename($domainModel->fqn),
             'factory' => $this->getFactoryName(),
+            'namespace' => $domainFactory->namespace,
         ];
     }
 
@@ -109,6 +112,6 @@ class MakeFactory extends DomainGeneratorCommand
             $name = substr($name, 0, -7);
         }
 
-        return (new Domain($this->getDomain()))->namespacedModel($name);
+        return (new Domain($this->getDomain()))->model($name)->name;
     }
 }

--- a/src/Factories/DomainFactory.php
+++ b/src/Factories/DomainFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+abstract class DomainFactory extends Factory
+{
+    /**
+     * Get the domain namespace.
+     *
+     * @return string
+     */
+    protected static function domainNamespace()
+    {
+        return basename(config('ddd.paths.domains')).'\\';
+    }
+
+    /**
+     * Get the factory name for the given domain model name.
+     *
+     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $modelName
+     * @return null|class-string<\Illuminate\Database\Eloquent\Factories\Factory>
+     */
+    public static function resolveFactoryName(string $modelName)
+    {
+        $resolver = function (string $modelName) {
+            $domainNamespace = static::domainNamespace();
+            $modelNamespace = config('ddd.namespaces.models');
+
+            // Expected domain model FQN:
+            // {DomainNamespace}\{Domain}\{ModelNamespace}\{Model}
+
+            if (! Str::startsWith($modelName, $domainNamespace)) {
+                // Not a domain model
+                return null;
+            }
+
+            $domain = str($modelName)
+                ->after($domainNamespace)
+                ->beforeLast($modelNamespace)
+                ->trim('\\')
+                ->toString();
+
+            $modelBaseName = class_basename($modelName);
+
+            return static::$namespace."{$domain}\\{$modelBaseName}Factory";
+        };
+
+        return $resolver($modelName);
+    }
+}

--- a/src/Models/DomainModel.php
+++ b/src/Models/DomainModel.php
@@ -3,9 +3,10 @@
 namespace Lunarstorm\LaravelDDD\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Lunarstorm\LaravelDDD\Factories\DomainFactory;
 
-abstract class DomainModel
+abstract class DomainModel extends Model
 {
     use HasFactory;
 

--- a/src/Models/DomainModel.php
+++ b/src/Models/DomainModel.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace {{ namespace }};
+namespace Lunarstorm\LaravelDDD\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Lunarstorm\LaravelDDD\Factories\DomainFactory;
-use Illuminate\Database\Eloquent\Model;
 
-abstract class {{ class }} extends Model
+abstract class DomainModel
 {
     use HasFactory;
 

--- a/src/Support/Domain.php
+++ b/src/Support/Domain.php
@@ -54,9 +54,7 @@ class Domain
 
         $this->namespace = DomainNamespaces::from($this->domain, $this->subdomain);
 
-        $this->path = str(app()->joinPaths(config('ddd.paths.domains'), $this->domainWithSubdomain))
-            ->replace(['\\', '/'], DIRECTORY_SEPARATOR)
-            ->toString();
+        $this->path = Path::join(config('ddd.paths.domains'), $this->domainWithSubdomain);
     }
 
     protected function getDomainBasePath()
@@ -76,7 +74,7 @@ class Domain
             ->append('.php')
             ->toString();
 
-        return app()->joinPaths($this->path, $path);
+        return Path::join($this->path, $path);
     }
 
     public function relativePath(string $path = ''): string

--- a/src/Support/Domain.php
+++ b/src/Support/Domain.php
@@ -2,36 +2,164 @@
 
 namespace Lunarstorm\LaravelDDD\Support;
 
+use Lunarstorm\LaravelDDD\ValueObjects\DomainNamespaces;
+use Lunarstorm\LaravelDDD\ValueObjects\DomainObject;
+
 class Domain
 {
-    public string $domainRoot;
+    public readonly string $dotName;
 
-    public function __construct(public string $domain)
+    public readonly string $path;
+
+    public readonly string $domain;
+
+    public readonly ?string $subdomain;
+
+    public readonly string $domainWithSubdomain;
+
+    public readonly DomainNamespaces $namespace;
+
+    public function __construct(string $domain, string $subdomain = null)
     {
-        $this->domainRoot = basename(config('ddd.paths.domains'));
+        if (is_null($subdomain)) {
+            // If a subdomain isn't explicitly specified, we
+            // will attempt to parse it from the domain.
+            $parts = str($domain)
+                ->replace(['\\', '/'], '.')
+                ->explode('.')
+                ->filter();
+
+            $domain = $parts->shift();
+
+            if ($parts->count() > 0) {
+                $subdomain = $parts->implode('.');
+            }
+        }
+
+        $domain = str($domain)->trim('\\/')->toString();
+
+        $subdomain = str($subdomain)->trim('\\/')->toString();
+
+        $this->domainWithSubdomain = str($domain)
+            ->when($subdomain, fn ($domain) => $domain->append("\\{$subdomain}"))
+            ->toString();
+
+        $this->domain = $domain;
+
+        $this->subdomain = $subdomain ?: null;
+
+        $this->dotName = $this->subdomain
+            ? "{$this->domain}.{$this->subdomain}"
+            : $this->domain;
+
+        $this->namespace = DomainNamespaces::from($this->domain, $this->subdomain);
+
+        $this->path = str(app()->joinPaths(config('ddd.paths.domains'), $this->domainWithSubdomain))
+            ->replace(['\\', '/'], DIRECTORY_SEPARATOR)
+            ->toString();
+    }
+
+    protected function getDomainBasePath()
+    {
+        return app()->basePath(config('ddd.paths.domains'));
+    }
+
+    public function path(string $path = null): string
+    {
+        if (is_null($path)) {
+            return $this->path;
+        }
+
+        $path = str($path)
+            ->replace($this->namespace->root, '')
+            ->replace(['\\', '/'], DIRECTORY_SEPARATOR)
+            ->append('.php')
+            ->toString();
+
+        return app()->joinPaths($this->path, $path);
     }
 
     public function relativePath(string $path = ''): string
     {
-        return implode(DIRECTORY_SEPARATOR, [
-            $this->domain,
-            $path,
-        ]);
+        return collect([$this->domain, $path])->filter()->implode(DIRECTORY_SEPARATOR);
     }
 
-    public function namespacedModel(?string $model): string
+    public function model(string $name): DomainObject
     {
-        $prefix = implode('\\', [
-            $this->domainRoot,
-            $this->domain,
-            config('ddd.namespaces.models'),
-        ]);
+        $name = str_replace($this->namespace->models.'\\', '', $name);
 
-        $model = str($model)
-            ->replace($prefix, '')
-            ->ltrim('\\')
-            ->toString();
+        return new DomainObject(
+            name: $name,
+            namespace: $this->namespace->models,
+            fqn: $this->namespace->models.'\\'.$name,
+            path: $this->path($this->namespace->models.'\\'.$name),
+        );
+    }
 
-        return implode('\\', [$prefix, $model]);
+    public function factory(string $name): DomainObject
+    {
+        $name = str_replace($this->namespace->factories.'\\', '', $name);
+
+        return new DomainObject(
+            name: $name,
+            namespace: $this->namespace->factories,
+            fqn: $this->namespace->factories.'\\'.$name,
+            path: str("database/factories/{$this->domainWithSubdomain}/{$name}.php")
+                ->replace(['\\', '/'], DIRECTORY_SEPARATOR)
+                ->toString()
+        );
+    }
+
+    public function dataTransferObject(string $name): DomainObject
+    {
+        $name = str_replace($this->namespace->dataTransferObjects.'\\', '', $name);
+
+        return new DomainObject(
+            name: $name,
+            namespace: $this->namespace->dataTransferObjects,
+            fqn: $this->namespace->dataTransferObjects.'\\'.$name,
+            path: $this->path($this->namespace->dataTransferObjects.'\\'.$name),
+        );
+    }
+
+    public function dto(string $name): DomainObject
+    {
+        return $this->dataTransferObject($name);
+    }
+
+    public function viewModel(string $name): DomainObject
+    {
+        $name = str_replace($this->namespace->viewModels.'\\', '', $name);
+
+        return new DomainObject(
+            name: $name,
+            namespace: $this->namespace->viewModels,
+            fqn: $this->namespace->viewModels.'\\'.$name,
+            path: $this->path($this->namespace->viewModels.'\\'.$name),
+        );
+    }
+
+    public function valueObject(string $name): DomainObject
+    {
+        $name = str_replace($this->namespace->valueObjects.'\\', '', $name);
+
+        return new DomainObject(
+            name: $name,
+            namespace: $this->namespace->valueObjects,
+            fqn: $this->namespace->valueObjects.'\\'.$name,
+            path: $this->path($this->namespace->valueObjects.'\\'.$name),
+        );
+    }
+
+    public function action(string $name): DomainObject
+    {
+        $name = str_replace($this->namespace->actions.'\\', '', $name);
+
+        return new DomainObject(
+            name: $name,
+            namespace: $this->namespace->actions,
+            fqn: $this->namespace->actions.'\\'.$name,
+            path: $this->path($this->namespace->actions.'\\'.$name),
+        );
     }
 }

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Support;
+
+class DomainResolver
+{
+    public static function fromModelClass(string $modelClass)
+    {
+    }
+}

--- a/src/Support/Path.php
+++ b/src/Support/Path.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Support;
+
+class Path
+{
+    public static function normalize($path)
+    {
+        return str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
+    }
+
+    public static function join(...$parts)
+    {
+        $parts = array_map(function ($part) {
+            return trim(static::normalize($part), DIRECTORY_SEPARATOR);
+        }, $parts);
+
+        return implode(DIRECTORY_SEPARATOR, $parts);
+    }
+}

--- a/src/ValueObjects/DomainNamespaces.php
+++ b/src/ValueObjects/DomainNamespaces.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\ValueObjects;
+
+class DomainNamespaces
+{
+    public function __construct(
+        public readonly string $root,
+        public readonly string $models,
+        public readonly string $factories,
+        public readonly string $dataTransferObjects,
+        public readonly string $viewModels,
+        public readonly string $valueObjects,
+        public readonly string $actions,
+    ) {
+    }
+
+    public static function from(string $domain, string $subdomain = null): self
+    {
+        $domainWithSubdomain = str($domain)
+            ->when($subdomain, fn ($domain) => $domain->append("\\{$subdomain}"))
+            ->toString();
+
+        $root = basename(config('ddd.paths.domains'));
+
+        $domainNamespace = implode('\\', [$root, $domainWithSubdomain]);
+
+        return new self(
+            root: $domainNamespace,
+            models: "{$domainNamespace}\\".config('ddd.namespaces.models'),
+            factories: "Database\\Factories\\{$domainWithSubdomain}",
+            dataTransferObjects: "{$domainNamespace}\\".config('ddd.namespaces.data_transfer_objects'),
+            viewModels: "{$domainNamespace}\\".config('ddd.namespaces.view_models'),
+            valueObjects: "{$domainNamespace}\\".config('ddd.namespaces.value_objects'),
+            actions: "{$domainNamespace}\\".config('ddd.namespaces.actions'),
+        );
+    }
+}

--- a/src/ValueObjects/DomainObject.php
+++ b/src/ValueObjects/DomainObject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\ValueObjects;
+
+class DomainObject
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $namespace,
+        public readonly string $fqn,
+        public readonly string $path,
+    ) {
+    }
+}

--- a/stubs/base-model.php.stub
+++ b/stubs/base-model.php.stub
@@ -14,9 +14,33 @@ abstract class {{ class }} extends Model
     protected static function newFactory()
     {
         $parts = str(get_called_class())->explode('\\');
-        $domain = $parts[1];
-        $model = $parts->last();
 
-        return app("Database\\Factories\\{$domain}\\{$model}Factory");
+        // Find the index of the "Models" directory
+        $modelsIndex = $parts->search("Models");
+
+        if ($modelsIndex === false) {
+            throw new Exception("Model class must be in a Models directory: {$parts->implode('\\')}");
+        }
+
+        // Extract domain and subdomain from before "Models"
+        /** @var int $modelsIndex */
+        $subdomain = $modelsIndex >= 3 ? $parts->get($modelsIndex - 1) : '';
+        $domain = $subdomain ? $parts->get($modelsIndex - 2) : $parts->get($modelsIndex - 1);
+
+        // Extract model name from after "Models"
+        $model = $parts->get($modelsIndex + 1);
+
+        // Build factory path
+        $factoryPath = "Database\\Factories\\{$domain}";
+        if ($subdomain) {
+            $factoryPath .= "\\{$subdomain}";
+        }
+        $factoryPath .= "\\{$model}Factory";
+
+        if (class_exists($factoryPath)) {
+            return app($factoryPath);
+        } else {
+            throw new Exception("Factory class does not exist: {$factoryPath}");
+        }
     }
 }

--- a/tests/Datasets/Domains.php
+++ b/tests/Datasets/Domains.php
@@ -6,3 +6,9 @@ dataset('domainPaths', [
     ['Custom/PathTo/Domain', 'Domain'],
     ['Custom/PathTo/Domains', 'Domains'],
 ]);
+
+dataset('domainSubdomain', [
+    // Domain, Subdomain
+    ['Customer', 'Reporting'],
+    ['Customer', null],
+]);

--- a/tests/Fixtures/Models/Invoice.php
+++ b/tests/Fixtures/Models/Invoice.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Tests\Fixtures\Models;
+
+use Lunarstorm\LaravelDDD\Models\DomainModel;
+
+class Invoice extends DomainModel
+{
+}

--- a/tests/Generator/MakeFactoryTest.php
+++ b/tests/Generator/MakeFactoryTest.php
@@ -33,9 +33,11 @@ it('can generate domain factories', function ($domainPath, $domainRoot, $domain,
 
     Artisan::call("ddd:factory {$domain->dotName} {$modelName}");
 
+    $outputPath = str_replace('\\', '/', $domainFactory->path);
+
     expect(Artisan::output())->when(
         Feature::IncludeFilepathInGeneratorCommandOutput->exists(),
-        fn ($output) => $output->toContain($domainFactory->path),
+        fn ($output) => $output->toContain($outputPath),
     );
 
     expect(file_exists($expectedFactoryPath))->toBeTrue(

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -76,9 +76,11 @@ it('can generate a domain model with factory', function ($domainPath, $domainRoo
         '--factory' => true,
     ]);
 
+    $outputPath = str_replace('\\', '/', $domainModel->path);
+
     expect(Artisan::output())->when(
         Feature::IncludeFilepathInGeneratorCommandOutput->exists(),
-        fn ($output) => $output->toContain($domainModel->path),
+        fn ($output) => $output->toContain($outputPath),
     );
 
     expect(file_exists($expectedModelPath))->toBeTrue();

--- a/tests/Model/FactoryTest.php
+++ b/tests/Model/FactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Artisan;
+use Lunarstorm\LaravelDDD\Factories\DomainFactory;
+
+it('can resolve the factory name of a domain model', function ($modelClass, $expectedFactoryClass) {
+    expect(DomainFactory::resolveFactoryName($modelClass))->toBe($expectedFactoryClass);
+})->with([
+    ["Domain\Customer\Models\Invoice", "Database\Factories\Customer\InvoiceFactory"],
+    ["Domain\Reports\Accounting\Models\InvoiceReport", "Database\Factories\Reports\Accounting\InvoiceReportFactory"],
+    ["App\Models\Invoice", null],
+]);
+
+it('can instantiate a domain model factory', function ($domainParameter, $modelName, $modelClass) {
+    Artisan::call("ddd:model -f {$domainParameter} {$modelName}");
+    expect(class_exists($modelClass))->toBeTrue();
+    expect($modelClass::factory())->toBeInstanceOf(Factory::class);
+})->with([
+    // Domain, Model, Model FQN
+    ['Fruits', 'Apple', 'Domain\Fruits\Models\Apple'],
+    ['Fruits.Citrus', 'Lime', 'Domain\Fruits\Citrus\Models\Lime'],
+]);

--- a/tests/Support/DomainTest.php
+++ b/tests/Support/DomainTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Lunarstorm\LaravelDDD\Support\Domain;
+
+it('can initialize a domain', function ($domainName, $subdomainName) {
+    $domain = new Domain($domainName, $subdomainName);
+
+    expect($domain)
+        ->domain->toBe($domainName)
+        ->subdomain->toBe($subdomainName);
+})->with('domainSubdomain');
+
+it('can extract domain and subdomain from dot or slash separated string', function ($domainName, $subdomainName, $separator) {
+    $dotPath = $subdomainName ? "{$domainName}{$separator}{$subdomainName}" : $domainName;
+    $domain = new Domain($dotPath);
+
+    expect($domain)
+        ->domain->toBe($domainName)
+        ->subdomain->toBe($subdomainName);
+})->with('domainSubdomain')->with(['.', '\\', '/']);
+
+it('can describe a domain model', function ($domainName, $name, $expectedFQN, $expectedPath) {
+    expect((new Domain($domainName))->model($name))
+        ->name->toBe($name)
+        ->fqn->toBe($expectedFQN)
+        ->path->toBe($expectedPath);
+})->with([
+    ['Reporting', 'InvoiceReport', 'Domain\\Reporting\\Models\\InvoiceReport', 'src/Domain/Reporting/Models/InvoiceReport.php'],
+    ['Reporting.Internal', 'InvoiceReport', 'Domain\\Reporting\\Internal\\Models\\InvoiceReport', 'src/Domain/Reporting/Internal/Models/InvoiceReport.php'],
+]);
+
+it('can describe a domain factory', function ($domainName, $name, $expectedFQN, $expectedPath) {
+    expect((new Domain($domainName))->factory($name))
+        ->name->toBe($name)
+        ->fqn->toBe($expectedFQN)
+        ->path->toBe($expectedPath);
+})->with([
+    ['Reporting', 'InvoiceReportFactory', 'Database\\Factories\\Reporting\\InvoiceReportFactory', 'database/factories/Reporting/InvoiceReportFactory.php'],
+    ['Reporting.Internal', 'InvoiceReportFactory', 'Database\\Factories\\Reporting\\Internal\\InvoiceReportFactory', 'database/factories/Reporting/Internal/InvoiceReportFactory.php'],
+]);
+
+it('can describe a data transfer object', function ($domainName, $name, $expectedFQN, $expectedPath) {
+    expect((new Domain($domainName))->dataTransferObject($name))
+        ->name->toBe($name)
+        ->fqn->toBe($expectedFQN)
+        ->path->toBe($expectedPath);
+})->with([
+    ['Reporting', 'InvoiceData', 'Domain\\Reporting\\Data\\InvoiceData', 'src/Domain/Reporting/Data/InvoiceData.php'],
+    ['Reporting.Internal', 'InvoiceData', 'Domain\\Reporting\\Internal\\Data\\InvoiceData', 'src/Domain/Reporting/Internal/Data/InvoiceData.php'],
+]);
+
+it('can describe a view model', function ($domainName, $name, $expectedFQN, $expectedPath) {
+    expect((new Domain($domainName))->viewModel($name))
+        ->name->toBe($name)
+        ->fqn->toBe($expectedFQN)
+        ->path->toBe($expectedPath);
+})->with([
+    ['Reporting', 'InvoiceReportViewModel', 'Domain\\Reporting\\ViewModels\\InvoiceReportViewModel', 'src/Domain/Reporting/ViewModels/InvoiceReportViewModel.php'],
+    ['Reporting.Internal', 'InvoiceReportViewModel', 'Domain\\Reporting\\Internal\\ViewModels\\InvoiceReportViewModel', 'src/Domain/Reporting/Internal/ViewModels/InvoiceReportViewModel.php'],
+]);
+
+it('can describe a value object', function ($domainName, $name, $expectedFQN, $expectedPath) {
+    expect((new Domain($domainName))->valueObject($name))
+        ->name->toBe($name)
+        ->fqn->toBe($expectedFQN)
+        ->path->toBe($expectedPath);
+})->with([
+    ['Reporting', 'InvoiceTotal', 'Domain\\Reporting\\ValueObjects\\InvoiceTotal', 'src/Domain/Reporting/ValueObjects/InvoiceTotal.php'],
+    ['Reporting.Internal', 'InvoiceTotal', 'Domain\\Reporting\\Internal\\ValueObjects\\InvoiceTotal', 'src/Domain/Reporting/Internal/ValueObjects/InvoiceTotal.php'],
+]);
+
+it('can describe an action', function ($domainName, $name, $expectedFQN, $expectedPath) {
+    expect((new Domain($domainName))->action($name))
+        ->name->toBe($name)
+        ->fqn->toBe($expectedFQN)
+        ->path->toBe($expectedPath);
+})->with([
+    ['Reporting', 'SendInvoiceReport', 'Domain\\Reporting\\Actions\\SendInvoiceReport', 'src/Domain/Reporting/Actions/SendInvoiceReport.php'],
+    ['Reporting.Internal', 'SendInvoiceReport', 'Domain\\Reporting\\Internal\\Actions\\SendInvoiceReport', 'src/Domain/Reporting/Internal/Actions/SendInvoiceReport.php'],
+]);

--- a/tests/Support/DomainTest.php
+++ b/tests/Support/DomainTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Lunarstorm\LaravelDDD\Support\Domain;
+use Lunarstorm\LaravelDDD\Support\Path;
 
 it('can initialize a domain', function ($domainName, $subdomainName) {
     $domain = new Domain($domainName, $subdomainName);
@@ -23,7 +24,7 @@ it('can describe a domain model', function ($domainName, $name, $expectedFQN, $e
     expect((new Domain($domainName))->model($name))
         ->name->toBe($name)
         ->fqn->toBe($expectedFQN)
-        ->path->toBe($expectedPath);
+        ->path->toBe(Path::normalize($expectedPath));
 })->with([
     ['Reporting', 'InvoiceReport', 'Domain\\Reporting\\Models\\InvoiceReport', 'src/Domain/Reporting/Models/InvoiceReport.php'],
     ['Reporting.Internal', 'InvoiceReport', 'Domain\\Reporting\\Internal\\Models\\InvoiceReport', 'src/Domain/Reporting/Internal/Models/InvoiceReport.php'],
@@ -33,7 +34,7 @@ it('can describe a domain factory', function ($domainName, $name, $expectedFQN, 
     expect((new Domain($domainName))->factory($name))
         ->name->toBe($name)
         ->fqn->toBe($expectedFQN)
-        ->path->toBe($expectedPath);
+        ->path->toBe(Path::normalize($expectedPath));
 })->with([
     ['Reporting', 'InvoiceReportFactory', 'Database\\Factories\\Reporting\\InvoiceReportFactory', 'database/factories/Reporting/InvoiceReportFactory.php'],
     ['Reporting.Internal', 'InvoiceReportFactory', 'Database\\Factories\\Reporting\\Internal\\InvoiceReportFactory', 'database/factories/Reporting/Internal/InvoiceReportFactory.php'],
@@ -43,7 +44,7 @@ it('can describe a data transfer object', function ($domainName, $name, $expecte
     expect((new Domain($domainName))->dataTransferObject($name))
         ->name->toBe($name)
         ->fqn->toBe($expectedFQN)
-        ->path->toBe($expectedPath);
+        ->path->toBe(Path::normalize($expectedPath));
 })->with([
     ['Reporting', 'InvoiceData', 'Domain\\Reporting\\Data\\InvoiceData', 'src/Domain/Reporting/Data/InvoiceData.php'],
     ['Reporting.Internal', 'InvoiceData', 'Domain\\Reporting\\Internal\\Data\\InvoiceData', 'src/Domain/Reporting/Internal/Data/InvoiceData.php'],
@@ -53,7 +54,7 @@ it('can describe a view model', function ($domainName, $name, $expectedFQN, $exp
     expect((new Domain($domainName))->viewModel($name))
         ->name->toBe($name)
         ->fqn->toBe($expectedFQN)
-        ->path->toBe($expectedPath);
+        ->path->toBe(Path::normalize($expectedPath));
 })->with([
     ['Reporting', 'InvoiceReportViewModel', 'Domain\\Reporting\\ViewModels\\InvoiceReportViewModel', 'src/Domain/Reporting/ViewModels/InvoiceReportViewModel.php'],
     ['Reporting.Internal', 'InvoiceReportViewModel', 'Domain\\Reporting\\Internal\\ViewModels\\InvoiceReportViewModel', 'src/Domain/Reporting/Internal/ViewModels/InvoiceReportViewModel.php'],
@@ -63,7 +64,7 @@ it('can describe a value object', function ($domainName, $name, $expectedFQN, $e
     expect((new Domain($domainName))->valueObject($name))
         ->name->toBe($name)
         ->fqn->toBe($expectedFQN)
-        ->path->toBe($expectedPath);
+        ->path->toBe(Path::normalize($expectedPath));
 })->with([
     ['Reporting', 'InvoiceTotal', 'Domain\\Reporting\\ValueObjects\\InvoiceTotal', 'src/Domain/Reporting/ValueObjects/InvoiceTotal.php'],
     ['Reporting.Internal', 'InvoiceTotal', 'Domain\\Reporting\\Internal\\ValueObjects\\InvoiceTotal', 'src/Domain/Reporting/Internal/ValueObjects/InvoiceTotal.php'],
@@ -73,7 +74,7 @@ it('can describe an action', function ($domainName, $name, $expectedFQN, $expect
     expect((new Domain($domainName))->action($name))
         ->name->toBe($name)
         ->fqn->toBe($expectedFQN)
-        ->path->toBe($expectedPath);
+        ->path->toBe(Path::normalize($expectedPath));
 })->with([
     ['Reporting', 'SendInvoiceReport', 'Domain\\Reporting\\Actions\\SendInvoiceReport', 'src/Domain/Reporting/Actions/SendInvoiceReport.php'],
     ['Reporting.Internal', 'SendInvoiceReport', 'Domain\\Reporting\\Internal\\Actions\\SendInvoiceReport', 'src/Domain/Reporting/Internal/Actions/SendInvoiceReport.php'],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -70,6 +70,7 @@ class TestCase extends Orchestra
 
         File::deleteDirectory(resource_path('stubs/ddd'));
         File::deleteDirectory(base_path('Custom'));
+        File::deleteDirectory(base_path('src/Domain'));
         File::deleteDirectory(base_path('src/Domains'));
     }
 }


### PR DESCRIPTION
- [x] Add test coverage
- [x] Refine and simplify where possible

### Added
- Formal support for subdomains (nested domains). For example, to generate model `Domain\Reporting\Internal\Models\InvoiceReport`, the domain argument can be specified in any of the following ways:
    - `ddd:model Reporting\\Internal InvoiceReport`
    - `ddd:model Reporting/Internal InvoiceReport`
    - `ddd:model Reporting.Internal InvoiceReport`
- Implement abstract `Lunarstorm\LaravelDDD\Factories\DomainFactory` extension of `Illuminate\Database\Eloquent\Factories\Factory`:
    - Implements `DomainFactory::resolveFactoryName()` to resolve the corresponding factory for a domain model.
    - Will resolve the correct factory if the model belongs to a subdomain; `Domain\Reporting\Internal\Models\InvoiceReport` will correctly resolve to `Database\Factories\Reporting\Internal\InvoiceReportFactory`.

### Changed
- Default base model implementation in `base-model.php.stub` now uses using `DomainFactory::factoryForModel()` inside the `newFactory` method to resolve the model factory.