### PR TITLE
Fix custom base model support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [Unversioned]
+### Changed
+- Implement more robust handling of base models when generating a domain model with `ddd:model`:
+    - If the configured base model class in `ddd.base_model` exists (evaluated using `class_exists`), base model creation is skipped.
+    - If the configured base model class does not exist, base model will be created, but only if the class falls under a domain scope.
+    - Examples of falling under domain scope: `Domain\Shared\Models\CustomDomainBaseModel`, `Domain\Infrastructure\Models\DomainModel`.
+    - Examples of not falling under domain scope: `App\Models\CustomAppBaseModel`, `Illuminate\Database\Eloquent\NonExistentModel`.
+
+### Fixed
+- Resolve long-standing issue where `ddd:model` would not properly detect whether the configured basemodel in `ddd.base_model` already exists, leading to unpredictable results when `ddd.base_model` deviated from the default `Domain\Shared\Models\BaseModel`.
+
 ## [0.7.0] - 2023-10-22
 ### Added
 - Formal support for subdomains (nested domains). For example, to generate model `Domain\Reporting\Internal\Models\InvoiceReport`, the domain argument can be specified with dot notation: `ddd:model Reporting.Internal InvoiceReport`. Specifying `Reporting/Internal` or `Reporting\\Internal` will also be accepted and normalized to dot notation internally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to `laravel-ddd` will be documented in this file.
 ## [Unversioned]
 ### Changed
 - Implement more robust handling of base models when generating a domain model with `ddd:model`:
-    - If the configured base model class in `ddd.base_model` exists (evaluated using `class_exists`), base model creation is skipped.
-    - If the configured base model class does not exist, base model will be created, but only if the class falls under a domain scope.
-    - Examples of falling under domain scope: `Domain\Shared\Models\CustomDomainBaseModel`, `Domain\Infrastructure\Models\DomainModel`.
-    - Examples of not falling under domain scope: `App\Models\CustomAppBaseModel`, `Illuminate\Database\Eloquent\NonExistentModel`.
+    - If the configured `ddd.base_model` exists (evaluated using `class_exists`), base model generation is skipped.
+    - If `ddd.base_model` does not exist and falls under a domain namespace, base model will be generated.
+    - Falling under a domain namespace means `Domain\**\Models\SomeBaseModel`.
+    - For example, if `ddd.base_model` were set to `App\Models\CustomAppBaseModel` or `Illuminate\Database\Eloquent\NonExistentModel`, they fall outside of the domain namespace and won't be generated on your behalf.
 
 ### Fixed
-- Resolve long-standing issue where `ddd:model` would not properly detect whether the configured basemodel in `ddd.base_model` already exists, leading to unpredictable results when `ddd.base_model` deviated from the default `Domain\Shared\Models\BaseModel`.
+- Resolve long-standing issue where `ddd:model` would not properly detect whether the configured `ddd.base_model` already exists, leading to unpredictable results when `ddd.base_model` deviated from the default `Domain\Shared\Models\BaseModel`.
+
+### Chore
+- Update composer dependencies.
 
 ## [0.7.0] - 2023-10-22
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
             "Lunarstorm\\LaravelDDD\\Tests\\": "tests",
             "App\\": "vendor/orchestra/testbench-core/laravel/app/",
             "Database\\Factories\\": "vendor/orchestra/testbench-core/laravel/database/factories/",
+            "Database\\Seeders\\": "vendor/orchestra/testbench-core/laravel/database/seeders/",
             "Domain\\": "vendor/orchestra/testbench-core/laravel/src/Domain/"
         }
     },

--- a/src/Commands/MakeModel.php
+++ b/src/Commands/MakeModel.php
@@ -81,7 +81,7 @@ class MakeModel extends DomainGeneratorCommand
 
         // base_path(config('ddd.paths.domains') . '/Shared/Models/BaseModel.php')
 
-        if (!file_exists($baseModelPath)) {
+        if (! file_exists($baseModelPath)) {
             $this->warn("Base model {$baseModel} doesn't exist, generating...");
 
             $this->call(MakeBaseModel::class, [
@@ -95,7 +95,7 @@ class MakeModel extends DomainGeneratorCommand
     {
         $this->call(MakeFactory::class, [
             'domain' => $this->getDomain(),
-            'name' => $this->getNameInput() . 'Factory',
+            'name' => $this->getNameInput().'Factory',
             '--model' => $this->qualifyClass($this->getNameInput()),
         ]);
     }

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -2,15 +2,13 @@
 
 namespace Lunarstorm\LaravelDDD\Support;
 
-use Illuminate\Support\Str;
-
 class DomainResolver
 {
-    public static function fromClass(string $class): ?Domain
+    public static function guessDomainFromClass(string $class): ?string
     {
         $domainNamespace = basename(config('ddd.paths.domains')).'\\';
 
-        if (! Str::startsWith($class, $domainNamespace)) {
+        if (! str($class)->startsWith($domainNamespace)) {
             // Not a domain model
             return null;
         }
@@ -20,6 +18,6 @@ class DomainResolver
             ->before('\\')
             ->toString();
 
-        return new Domain($domain);
+        return $domain;
     }
 }

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -2,9 +2,24 @@
 
 namespace Lunarstorm\LaravelDDD\Support;
 
+use Illuminate\Support\Str;
+
 class DomainResolver
 {
-    public static function fromModelClass(string $modelClass)
+    public static function fromClass(string $class): ?Domain
     {
+        $domainNamespace = basename(config('ddd.paths.domains')).'\\';
+
+        if (! Str::startsWith($class, $domainNamespace)) {
+            // Not a domain model
+            return null;
+        }
+
+        $domain = str($class)
+            ->after($domainNamespace)
+            ->before('\\')
+            ->toString();
+
+        return new Domain($domain);
     }
 }

--- a/stubs/model.php.stub
+++ b/stubs/model.php.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use {{ rootNamespace }}\Shared\Models\BaseModel;
+{{ baseClassImport }}
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class {{ class }}{{ extends }}

--- a/stubs/model.php.stub
+++ b/stubs/model.php.stub
@@ -5,7 +5,7 @@ namespace {{ namespace }};
 use {{ rootNamespace }}\Shared\Models\BaseModel;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class {{ class }} extends BaseModel
+class {{ class }}{{ extends }}
 {
     use SoftDeletes;
 

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -106,9 +106,11 @@ it('normalizes generated model to pascal case', function ($given, $normalized) {
     expect(file_exists($expectedModelPath))->toBeTrue();
 })->with('makeModelInputs');
 
-it('generates the base model when possible', function () {
+it('generates the base model when possible', function ($baseModelClass, $baseModelPath) {
     $modelName = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
+
+    Config::set('ddd.base_model', $baseModelClass);
 
     $expectedModelPath = base_path(implode('/', [
         config('ddd.paths.domains'),
@@ -123,23 +125,36 @@ it('generates the base model when possible', function () {
 
     expect(file_exists($expectedModelPath))->toBeFalse();
 
-    // This currently only tests for the default base model
-    $expectedBaseModelPath = base_path(config('ddd.paths.domains').'/Shared/Models/BaseModel.php');
+    $expectedBaseModelPath = base_path($baseModelPath);
 
     if (file_exists($expectedBaseModelPath)) {
         unlink($expectedBaseModelPath);
     }
 
-    // Todo: should bypass base model creation if
-    // a custom base model is being used.
-    // $baseModel = config('ddd.base_model');
-
-    expect(file_exists($expectedBaseModelPath))->toBeFalse();
+    expect(file_exists($expectedBaseModelPath))->toBeFalse("{$baseModelPath} expected not to exist.");
 
     Artisan::call("ddd:model {$domain} {$modelName}");
 
-    expect(file_exists($expectedBaseModelPath))->toBeTrue();
-});
+    expect(file_exists($expectedBaseModelPath))->toBeTrue("{$baseModelPath} expected to exist.");
+})->with([
+    ['Domain\\Shared\\Models\\BaseModel', 'src/Domain/Shared/Models/BaseModel.php'],
+    ['Domain\\Infrastructure\\Models\\BaseModel', 'src/Domain/Infrastructure/Models/BaseModel.php'],
+]);
+
+it('will not create a base model if the configured base model is out of scope', function ($baseModel) {
+    Config::set('ddd.base_model', $baseModel);
+
+    expect(class_exists($baseModel))->toBeFalse();
+
+    Artisan::call('ddd:model Fruits Lemon');
+
+    expect(Artisan::output())
+        ->toContain("Configured base model {$baseModel} doesn't exist.")
+        ->not->toContain("Generating {$baseModel}");
+})->with([
+    ['Illuminate\\Database\\Eloquent\\NonExistentModel'],
+    ['OtherVendor\\OtherPackage\\Models\\OtherModel'],
+]);
 
 it('skips base model creation if configured base model already exists', function ($baseModel) {
     Config::set('ddd.base_model', $baseModel);
@@ -148,10 +163,12 @@ it('skips base model creation if configured base model already exists', function
 
     Artisan::call('ddd:model Fruits Lemon');
 
-    expect(Artisan::output())->not->toContain("Base model {$baseModel} doesn't exist, generating...");
+    expect(Artisan::output())
+        ->not->toContain("Configured base model {$baseModel} doesn't exist.")
+        ->not->toContain("Generating {$baseModel}");
 })->with([
-    ['Illuminate\Database\Eloquent\Model'],
-    ['Lunarstorm\LaravelDDD\Models\DomainModel'],
+    ['Illuminate\\Database\\Eloquent\\Model'],
+    ['Lunarstorm\\LaravelDDD\\Models\\DomainModel'],
 ]);
 
 it('shows meaningful hints when prompting for missing input', function () {

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -106,7 +106,7 @@ it('normalizes generated model to pascal case', function ($given, $normalized) {
     expect(file_exists($expectedModelPath))->toBeTrue();
 })->with('makeModelInputs');
 
-it('generates the base model if needed', function () {
+it('generates the base model when possible', function () {
     $modelName = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
 
@@ -140,6 +140,19 @@ it('generates the base model if needed', function () {
 
     expect(file_exists($expectedBaseModelPath))->toBeTrue();
 });
+
+it('skips base model creation if configured base model already exists', function ($baseModel) {
+    Config::set('ddd.base_model', $baseModel);
+
+    expect(class_exists($baseModel))->toBeTrue();
+
+    Artisan::call('ddd:model Fruits Lemon');
+
+    expect(Artisan::output())->not->toContain("Base model {$baseModel} doesn't exist, generating...");
+})->with([
+    ['Illuminate\Database\Eloquent\Model'],
+    ['Lunarstorm\LaravelDDD\Models\DomainModel'],
+]);
 
 it('shows meaningful hints when prompting for missing input', function () {
     $this->artisan('ddd:model')

--- a/tests/Model/FactoryTest.php
+++ b/tests/Model/FactoryTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
 use Lunarstorm\LaravelDDD\Factories\DomainFactory;
 
 it('can resolve the factory name of a domain model', function ($modelClass, $expectedFactoryClass) {
@@ -13,6 +14,7 @@ it('can resolve the factory name of a domain model', function ($modelClass, $exp
 ]);
 
 it('can instantiate a domain model factory', function ($domainParameter, $modelName, $modelClass) {
+    Config::set('ddd.base_model', 'Lunarstorm\LaravelDDD\Models\DomainModel');
     Artisan::call("ddd:model -f {$domainParameter} {$modelName}");
     expect(class_exists($modelClass))->toBeTrue();
     expect($modelClass::factory())->toBeInstanceOf(Factory::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,7 @@ class TestCase extends Orchestra
 
         // Reset the domain namespace
         Arr::forget($data, ['autoload', 'psr-4', 'Domains\\']);
+        Arr::forget($data, ['autoload', 'psr-4', 'Domain\\']);
 
         // Set up the essential app namespaces
         data_set($data, ['autoload', 'psr-4', 'App\\'], 'vendor/orchestra/testbench-core/laravel/app');
@@ -36,7 +37,9 @@ class TestCase extends Orchestra
             fn (string $modelName) => 'Lunarstorm\\LaravelDDD\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
 
-        $this->beforeApplicationDestroyed(fn () => $this->cleanFilesAndFolders());
+        $this->beforeApplicationDestroyed(function () {
+            $this->cleanFilesAndFolders();
+        });
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
### Changed
- Implement more robust handling of base models when generating a domain model with `ddd:model`:
    - If the configured `ddd.base_model` exists (evaluated using `class_exists`), base model generation is skipped.
    - If `ddd.base_model` does not exist and falls under a domain namespace, base model will be generated.
    - Falling under a domain namespace means `Domain\**\Models\SomeBaseModel`.
    - For example, if `ddd.base_model` were set to `App\Models\CustomAppBaseModel` or `Illuminate\Database\Eloquent\NonExistentModel`, they fall outside of the domain namespace and won't be generated on your behalf.

### Fixed
- Resolve long-standing issue where `ddd:model` would not properly detect whether the configured `ddd.base_model` already exists, leading to unpredictable results when `ddd.base_model` deviated from the default `Domain\Shared\Models\BaseModel`.
