### PR TITLE
Refactor domain path and namespace configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [Unversioned]
+### Added
+- Config keys `ddd.domain_path` and `ddd.domain_namespace` added to specify path to the domain folder and root domain namespace. This allows a custom domain namespace if it differs from the basename of the domain path. e.g., `src/Domains` domain folder, but with `Domain` namespace.
+
+### Deprecated
+- Config `ddd.paths.domains` deprecated in favour of `ddd.domain_path` and `ddd.domain_namespace`.
+
 ## [0.9.0] - 2024-03-11
 ### Changed
 - Internals: normalize generator file paths using `DIRECTORY_SEPARATOR` for consistency across different operating systems when it comes to console output and test expectations.

--- a/README.md
+++ b/README.md
@@ -82,20 +82,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Paths
+    | Domain Path
     |--------------------------------------------------------------------------
     |
-    | This value contains paths to the layers of the application in the context
-    | of domain driven design, relative to the base folder of the application.
+    | The path to the domain folder relative to the application root.
     |
     */
+    'domain_path' => 'src/Domain',
 
-    'paths' => [
-        //
-        // Path to the Domain layer.
-        //
-        'domains' => 'src/Domain',
-    ],
+    /*
+    |--------------------------------------------------------------------------
+    | Domain Namespace
+    |--------------------------------------------------------------------------
+    |
+    | The root domain namespace.
+    |
+    */
+    'domain_namespace' => 'Domain',
 
     /*
     |--------------------------------------------------------------------------
@@ -114,29 +117,10 @@ return [
     |
     */
     'namespaces' => [
-        //
-        // Models
-        //
         'models' => 'Models',
-
-        //
-        // Data Transfer Objects (DTO)
-        //
         'data_transfer_objects' => 'Data',
-
-        //
-        // View Models
-        //
         'view_models' => 'ViewModels',
-
-        //
-        // Value Objects
-        //
         'value_objects' => 'ValueObjects',
-
-        //
-        // Actions
-        //
         'actions' => 'Actions',
     ],
 

--- a/config/ddd.php
+++ b/config/ddd.php
@@ -4,20 +4,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Paths
+    | Domain Path
     |--------------------------------------------------------------------------
     |
-    | This value contains paths to the layers of the application in the context
-    | of domain driven design, relative to the base folder of the application.
+    | The path to the domain folder relative to the application root.
     |
     */
+    'domain_path' => 'src/Domain',
 
-    'paths' => [
-        //
-        // Path to the Domain layer.
-        //
-        'domains' => 'src/Domain',
-    ],
+    /*
+    |--------------------------------------------------------------------------
+    | Domain Namespace
+    |--------------------------------------------------------------------------
+    |
+    | The root domain namespace.
+    |
+    */
+    'domain_namespace' => 'Domain',
 
     /*
     |--------------------------------------------------------------------------
@@ -36,29 +39,10 @@ return [
     |
     */
     'namespaces' => [
-        //
-        // Models
-        //
         'models' => 'Models',
-
-        //
-        // Data Transfer Objects (DTO)
-        //
         'data_transfer_objects' => 'Data',
-
-        //
-        // View Models
-        //
         'view_models' => 'ViewModels',
-
-        //
-        // Value Objects
-        //
         'value_objects' => 'ValueObjects',
-
-        //
-        // Actions
-        //
         'actions' => 'Actions',
     ],
 

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -4,6 +4,7 @@ namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Lunarstorm\LaravelDDD\Support\DomainResolver;
 use Lunarstorm\LaravelDDD\Support\Path;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -22,9 +23,8 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
 
     protected function rootNamespace()
     {
-        return str($this->getDomainBasePath())
+        return str(DomainResolver::getConfiguredDomainNamespace())
             ->rtrim('/\\')
-            ->basename()
             ->toString();
     }
 
@@ -58,7 +58,9 @@ abstract class DomainGeneratorCommand extends GeneratorCommand
 
     protected function getDomainBasePath()
     {
-        return Path::normalize($this->laravel->basePath(config('ddd.paths.domains', 'src/Domains')));
+        return Path::normalize($this->laravel->basePath(
+            DomainResolver::getConfiguredDomainPath() ?? 'src/Domain'
+        ));
     }
 
     protected function getPath($name)

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Lunarstorm\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
+use Lunarstorm\LaravelDDD\Support\DomainResolver;
 use Symfony\Component\Process\Process;
 
 class InstallCommand extends Command
@@ -34,11 +35,10 @@ class InstallCommand extends Command
 
     public function registerDomainAutoload()
     {
-        $domainPath = config('ddd.paths.domains');
+        $domainPath = DomainResolver::getConfiguredDomainPath();
 
-        $domainRootNamespace = str($domainPath)
+        $domainRootNamespace = str(DomainResolver::getConfiguredDomainNamespace())
             ->rtrim('/\\')
-            ->basename()
             ->toString();
 
         $this->comment("Registering domain path `{$domainPath}` in composer.json...");

--- a/src/Factories/DomainFactory.php
+++ b/src/Factories/DomainFactory.php
@@ -4,6 +4,7 @@ namespace Lunarstorm\LaravelDDD\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use Lunarstorm\LaravelDDD\Support\DomainResolver;
 
 abstract class DomainFactory extends Factory
 {
@@ -14,7 +15,7 @@ abstract class DomainFactory extends Factory
      */
     protected static function domainNamespace()
     {
-        return basename(config('ddd.paths.domains')).'\\';
+        return Str::finish(DomainResolver::getConfiguredDomainNamespace(), '\\');
     }
 
     /**

--- a/src/Support/Domain.php
+++ b/src/Support/Domain.php
@@ -54,12 +54,12 @@ class Domain
 
         $this->namespace = DomainNamespaces::from($this->domain, $this->subdomain);
 
-        $this->path = Path::join(config('ddd.paths.domains'), $this->domainWithSubdomain);
+        $this->path = Path::join(DomainResolver::getConfiguredDomainPath(), $this->domainWithSubdomain);
     }
 
     protected function getDomainBasePath()
     {
-        return app()->basePath(config('ddd.paths.domains'));
+        return app()->basePath(DomainResolver::getConfiguredDomainPath());
     }
 
     public function path(?string $path = null): string

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -31,7 +31,7 @@ class DomainResolver
     {
         $domainNamespace = Str::finish(DomainResolver::getConfiguredDomainNamespace(), '\\');
 
-        if (!str($class)->startsWith($domainNamespace)) {
+        if (! str($class)->startsWith($domainNamespace)) {
             // Not a domain model
             return null;
         }

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -2,13 +2,36 @@
 
 namespace Lunarstorm\LaravelDDD\Support;
 
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
 class DomainResolver
 {
+    public static function getConfiguredDomainPath(): string
+    {
+        if (Config::has('ddd.paths.domains')) {
+            // Deprecated
+            return config('ddd.paths.domains');
+        }
+
+        return config('ddd.domain_path');
+    }
+
+    public static function getConfiguredDomainNamespace(): string
+    {
+        if (Config::has('ddd.paths.domains')) {
+            // Deprecated
+            return basename(config('ddd.paths.domains'));
+        }
+
+        return config('ddd.domain_namespace');
+    }
+
     public static function guessDomainFromClass(string $class): ?string
     {
-        $domainNamespace = basename(config('ddd.paths.domains')).'\\';
+        $domainNamespace = Str::finish(DomainResolver::getConfiguredDomainNamespace(), '\\');
 
-        if (! str($class)->startsWith($domainNamespace)) {
+        if (!str($class)->startsWith($domainNamespace)) {
             // Not a domain model
             return null;
         }

--- a/src/ValueObjects/DomainNamespaces.php
+++ b/src/ValueObjects/DomainNamespaces.php
@@ -2,6 +2,8 @@
 
 namespace Lunarstorm\LaravelDDD\ValueObjects;
 
+use Lunarstorm\LaravelDDD\Support\DomainResolver;
+
 class DomainNamespaces
 {
     public function __construct(
@@ -21,7 +23,7 @@ class DomainNamespaces
             ->when($subdomain, fn ($domain) => $domain->append("\\{$subdomain}"))
             ->toString();
 
-        $root = basename(config('ddd.paths.domains'));
+        $root = DomainResolver::getConfiguredDomainNamespace();
 
         $domainNamespace = implode('\\', [$root, $domainWithSubdomain]);
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Lunarstorm\LaravelDDD\Support\DomainResolver;
+
+it('can customize the domain path via ddd.domain_path', function () {
+    $path = fake()->word();
+
+    Config::set('ddd.domain_path', $path);
+
+    expect(DomainResolver::getConfiguredDomainPath())->toEqual($path);
+});
+
+it('can customize the domain root namespace via ddd.domain_namespace', function () {
+    Config::set('ddd.domain_namespace', 'Doughmain');
+
+    expect(DomainResolver::getConfiguredDomainNamespace())->toEqual('Doughmain');
+});

--- a/tests/Generator/MakeActionTest.php
+++ b/tests/Generator/MakeActionTest.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Str;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate action objects', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $name = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
@@ -48,7 +49,7 @@ it('normalizes generated action object to pascal case', function ($given, $norma
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.actions'),
         "{$normalized}.php",
@@ -73,7 +74,7 @@ it('extends a base action if specified in config', function ($baseAction) {
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.actions'),
         "{$name}.php",
@@ -100,7 +101,7 @@ it('does not extend a base action if not specified in config', function () {
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.actions'),
         "{$name}.php",

--- a/tests/Generator/MakeBaseModelTest.php
+++ b/tests/Generator/MakeBaseModelTest.php
@@ -5,7 +5,8 @@ use Illuminate\Support\Facades\Config;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate domain base model', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $modelName = 'BaseModel';
     $domain = 'Shared';

--- a/tests/Generator/MakeBaseViewModelTest.php
+++ b/tests/Generator/MakeBaseViewModelTest.php
@@ -5,7 +5,8 @@ use Illuminate\Support\Facades\Config;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate base view model', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $className = 'ViewModel';
     $domain = 'Shared';

--- a/tests/Generator/MakeDataTransferObjectTest.php
+++ b/tests/Generator/MakeDataTransferObjectTest.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Str;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate data transfer objects', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $dtoName = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
@@ -48,7 +49,7 @@ it('normalizes generated data transfer object to pascal case', function ($given,
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.data_transfer_objects'),
         "{$normalized}.php",

--- a/tests/Generator/MakeFactoryTest.php
+++ b/tests/Generator/MakeFactoryTest.php
@@ -8,7 +8,8 @@ use Lunarstorm\LaravelDDD\Support\Path;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate domain factories', function ($domainPath, $domainRoot, $domain, $subdomain) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $modelName = Str::studly(fake()->word());
 

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -7,7 +7,8 @@ use Lunarstorm\LaravelDDD\Support\Domain;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate domain models', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $modelName = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
@@ -46,7 +47,7 @@ it('can generate domain models', function ($domainPath, $domainRoot) {
 })->with('domainPaths');
 
 it('can generate a domain model with factory', function ($domainPath, $domainRoot, $domainName, $subdomain) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
 
     $modelName = Str::studly(fake()->word());
 
@@ -93,7 +94,7 @@ it('normalizes generated model to pascal case', function ($given, $normalized) {
     $domain = Str::studly(fake()->word());
 
     $expectedModelPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.models'),
         "{$normalized}.php",
@@ -111,14 +112,14 @@ it('generates the base model when possible', function ($baseModelClass, $baseMod
     Config::set('ddd.base_model', $baseModelClass);
 
     $expectedModelPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.models'),
         "{$modelName}.php",
     ]));
 
     $expectedModelClass = implode('\\', [
-        basename(config('ddd.paths.domains')),
+        basename(config('ddd.domain_path')),
         $domain,
         config('ddd.namespaces.models'),
         $modelName,

--- a/tests/Generator/MakeValueObjectTest.php
+++ b/tests/Generator/MakeValueObjectTest.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Str;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate value objects', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $valueObjectName = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
@@ -48,7 +49,7 @@ it('normalizes generated value object to pascal case', function ($given, $normal
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.value_objects'),
         "{$normalized}.php",

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -78,7 +78,7 @@ it('generates the base view model if needed', function () {
     expect(file_exists($expectedPath))->toBeFalse();
 
     // This currently only tests for the default base model
-    $expectedBaseViewModelPath = base_path(config('ddd.domain_path') . '/Shared/ViewModels/ViewModel.php');
+    $expectedBaseViewModelPath = base_path(config('ddd.domain_path').'/Shared/ViewModels/ViewModel.php');
 
     if (file_exists($expectedBaseViewModelPath)) {
         unlink($expectedBaseViewModelPath);

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Str;
 use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate view models', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $viewModelName = Str::studly(fake()->word());
     $domain = Str::studly(fake()->word());
@@ -48,7 +49,7 @@ it('normalizes generated view model to pascal case', function ($given, $normaliz
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.view_models'),
         "{$normalized}.php",
@@ -64,7 +65,7 @@ it('generates the base view model if needed', function () {
     $domain = Str::studly(fake()->word());
 
     $expectedPath = base_path(implode('/', [
-        config('ddd.paths.domains'),
+        config('ddd.domain_path'),
         $domain,
         config('ddd.namespaces.view_models'),
         "{$className}.php",
@@ -77,7 +78,7 @@ it('generates the base view model if needed', function () {
     expect(file_exists($expectedPath))->toBeFalse();
 
     // This currently only tests for the default base model
-    $expectedBaseViewModelPath = base_path(config('ddd.paths.domains').'/Shared/ViewModels/ViewModel.php');
+    $expectedBaseViewModelPath = base_path(config('ddd.domain_path') . '/Shared/ViewModels/ViewModel.php');
 
     if (file_exists($expectedBaseViewModelPath)) {
         unlink($expectedBaseViewModelPath);

--- a/tests/InstallTest.php
+++ b/tests/InstallTest.php
@@ -25,7 +25,8 @@ it('publishes config', function () {
 });
 
 it('can initialize composer.json', function ($domainPath, $domainRoot) {
-    Config::set('ddd.paths.domains', $domainPath);
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
 
     $data = json_decode(file_get_contents(base_path('composer.json')), true);
     $before = data_get($data, ['autoload', 'psr-4', $domainRoot.'\\']);
@@ -37,7 +38,7 @@ it('can initialize composer.json', function ($domainPath, $domainRoot) {
 
     $data = json_decode(file_get_contents(base_path('composer.json')), true);
     $after = data_get($data, ['autoload', 'psr-4', $domainRoot.'\\']);
-    expect($after)->toEqual(config('ddd.paths.domains'));
+    expect($after)->toEqual(config('ddd.domain_path'));
 
     unlink(config_path('ddd.php'));
 })->with([


### PR DESCRIPTION
### Added
- Config keys `ddd.domain_path` and `ddd.domain_namespace` added to specify path to the domain folder and root domain namespace. This allows a custom domain namespace if it differs from the basename of the domain path. e.g., `src/Domains` domain folder, but with `Domain` namespace.

### Deprecated
- Config `ddd.paths.domains` deprecated in favour of `ddd.domain_path` and `ddd.domain_namespace`.