### PR TITLE
HasDomainFactory trait implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to `laravel-ddd` will be documented in this file.
 
 ## [Unversioned]
 ### Added
-- Config keys `ddd.domain_path` and `ddd.domain_namespace` added to specify path to the domain folder and root domain namespace. This allows a custom domain namespace if it differs from the basename of the domain path. e.g., `src/Domains` domain folder, but with `Domain` namespace.
+- Add `ddd.domain_path` and `ddd.domain_namespace` to config, to specify the path to the domain layer and root domain namespace more explicitly (replaces the previous `ddd.paths.domains` config).
+- Implement `Lunarstorm\LaravelDDD\Factories\HasDomainFactory` trait which can be used on domain models that are unable to extend the base domain model.
+
+### Changed
+- Default `base-model.php.stub` now utilizes the `HasDomainFactory` trait.
 
 ### Deprecated
-- Config `ddd.paths.domains` deprecated in favour of `ddd.domain_path` and `ddd.domain_namespace`.
+- Config `ddd.paths.domains` deprecated in favour of `ddd.domain_path` and `ddd.domain_namespace`. Existing config files published prior to this release should remove `ddd.paths.domains` and add `ddd.domain_path` and `ddd.domain_namespace` accordingly.
 
 ## [0.9.0] - 2024-03-11
 ### Changed

--- a/src/Factories/HasDomainFactory.php
+++ b/src/Factories/HasDomainFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Factories;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+trait HasDomainFactory
+{
+    use HasFactory;
+
+    protected static function newFactory()
+    {
+        return DomainFactory::factoryForModel(get_called_class());
+    }
+}

--- a/src/Models/DomainModel.php
+++ b/src/Models/DomainModel.php
@@ -2,18 +2,12 @@
 
 namespace Lunarstorm\LaravelDDD\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Lunarstorm\LaravelDDD\Factories\DomainFactory;
+use Lunarstorm\LaravelDDD\Factories\HasDomainFactory;
 
 abstract class DomainModel extends Model
 {
-    use HasFactory;
+    use HasDomainFactory;
 
     protected $guarded = [];
-
-    protected static function newFactory()
-    {
-        return DomainFactory::factoryForModel(get_called_class());
-    }
 }

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 
 class DomainResolver
 {
-    public static function getConfiguredDomainPath(): string
+    public static function getConfiguredDomainPath(): ?string
     {
         if (Config::has('ddd.paths.domains')) {
             // Deprecated
@@ -17,7 +17,7 @@ class DomainResolver
         return config('ddd.domain_path');
     }
 
-    public static function getConfiguredDomainNamespace(): string
+    public static function getConfiguredDomainNamespace(): ?string
     {
         if (Config::has('ddd.paths.domains')) {
             // Deprecated

--- a/stubs/base-model.php.stub
+++ b/stubs/base-model.php.stub
@@ -2,18 +2,12 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Lunarstorm\LaravelDDD\Factories\DomainFactory;
+use Lunarstorm\LaravelDDD\Factories\HasDomainFactory;
 use Illuminate\Database\Eloquent\Model;
 
 abstract class {{ class }} extends Model
 {
-    use HasFactory;
+    use HasDomainFactory;
 
     protected $guarded = [];
-
-    protected static function newFactory()
-    {
-        return DomainFactory::factoryForModel(get_called_class());
-    }
 }


### PR DESCRIPTION
### Added
- Implement `Lunarstorm\LaravelDDD\Factories\HasDomainFactory` trait which can be used on domain models that are unable to extend the base domain model.

### Changed
- Default `base-model.php.stub` now utilizes the `HasDomainFactory` trait.