### PR TITLE
Feature: Make Domain command

### DIFF
--- a/config/ddd.php
+++ b/config/ddd.php
@@ -110,4 +110,26 @@ return [
     |
     */
     'base_action' => null,
+
+
+    'make_domain_structure' => [
+        'Actions' => '',
+        'Commands' => '',
+        'Data' => '',
+        'Enums' => '',
+        'Exceptions' => '',
+        'Database' => [
+            'Factories' => '',
+            'Migrations' => '',
+            'Seeders' => '',
+        ],
+        'Jobs' => '',
+        'Models' => '',
+        'Policies' => '',
+        'Providers' => [
+            'files' => [
+                BaseServiceProvider::class, // How should we specify file you want created? Should use the logic the make commands
+            ]
+        ],
+    ]
 ];

--- a/src/Commands/MakeDomainCommand.php
+++ b/src/Commands/MakeDomainCommand.php
@@ -13,6 +13,7 @@ class MakeDomainCommand extends Command implements PromptsForMissingInput
 
     protected $description = 'Create a new domain';
 
+    protected string $domain;
     protected mixed $domainStructure;
     protected ?string $domainPath;
     protected ?string $domainRootNamespace;

--- a/src/Commands/MakeDomainCommand.php
+++ b/src/Commands/MakeDomainCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Symfony\Component\Process\Process;
+
+class MakeDomainCommand extends Command implements PromptsForMissingInput
+{
+    public $signature = 'ddd:make-domain {domain}';
+
+    protected $description = 'Create a new domain';
+
+    protected mixed $domainStructure;
+    protected ?string $domainPath;
+    protected ?string $domainRootNamespace;
+
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            'domain' => ['What is the name of the domain?', 'E.g. Payments']
+        ];
+    }
+
+    public function handle(): int
+    {
+        $domain = $this->argument('domain');
+
+        if (empty($domain)) {
+            $this->error('Domain name is required');
+            return self::FAILURE;
+        }
+
+        $this->domain = ucfirst($domain);
+
+        $this->domainStructure = config('ddd.make_domain_structure');
+        $this->domainPath = DomainResolver::domainPath().'/'.$this->domain;
+        $this->domainRootNamespace = DomainResolver::domainRootNamespace().'\\'.$domain;
+
+        $this->createDomainStructure($this->domainStructure);
+
+        return self::SUCCESS;
+    }
+
+    protected function createDomainStructure($domainStructure, $currentDir = ''): void
+    {
+        foreach ($domainStructure as $directory => $content) {
+            $this->createDirectoryWithContents($this->domainPath, $directory, $content);
+        }
+
+        $this->info('Domain structure created');
+    }
+
+    protected function createDirectoryWithContents($path, $directory, $content): void
+    {
+        $path .= '/' . $directory;
+        if (!is_dir($path)) {
+            if (! mkdir($path, 0755, true) && ! is_dir($path)) {
+                throw new \RuntimeException(sprintf('Directory "%s" was not created', $path));
+            }
+        }
+
+        if (empty($content)) {
+            return;
+        }
+
+        if (is_array($content)) {
+            if (isset($content['files']) && is_array($content['files'])) {
+
+                $this->createFiles($path, $content['files']);
+                unset($content['files']);
+            }
+
+            foreach ($content as $subDirectory => $subContent) {
+                $this->createDirectoryWithContents($path, $subDirectory, $subContent);
+            }
+        }
+    }
+
+    protected function createFiles($path, $files): void
+    {
+        foreach ($files as $file) {
+            $this->createFile($path, $file, $this->domainRootNamespace);
+        }
+    }
+
+    protected function createFile(string $path, string $file, string $namespace): void
+    {
+        // TODO: Make proper implementation
+        $file = $path.'/'.$file.'.php';
+        if (!file_exists($file)) {
+            $content = file_get_contents(__DIR__.'/../BaseServiceProvider.php');
+            file_put_contents($file, $content);
+        }
+    }
+}

--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -19,6 +19,7 @@ class LaravelDDDServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasCommands([
                 Commands\InstallCommand::class,
+                Commands\MakeDomainCommand::class,
                 Commands\DomainListCommand::class,
                 Commands\DomainModelMakeCommand::class,
                 Commands\DomainFactoryMakeCommand::class,


### PR DESCRIPTION
Works: Creates the configured directory structure for the domain

TODO: 
- [ ] Decide how you should specify files that should be generated in the config file
- [ ] Create the files when running the command. This should use the same logic as the make commands. Would you want something more than a service provider by default? 
- [ ] Add Documentation in readme and comment in config file

What are your thoughts @JasperTey ?
What do you think about the config format?
How should file generation be added? 