### PR TITLE
[1.x] Generate factories within domain layer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,14 @@ All notable changes to `laravel-ddd` will be documented in this file.
 - Support for autoloading and discovery of domain service providers, commands, policies, and factories.
 
 ### Changed
-- Minimum supported Laravel version is now 10.25.
 - (BREAKING) For applications that published the config prior to this release, config should be removed, re-published, and re-configured.
 - (BREAKING) Generator commands no longer receive a domain argument. Instead of `ddd:action Invoicing CreateInvoice`, one of the following would be used:
     - Using the --domain option: `ddd:action CreateInvoice --domain=Invoicing` (this takes precedence).
     - Shorthand syntax: `ddd:action Invoicing:CreateInvoice`.
     - Or simply `ddd:action CreateInvoice` to be prompted for the domain afterwards.
 - Improved the reliability of generating base view models when `ddd.base_view_model` is something other than the default `Domain\Shared\ViewModels\ViewModel`.
+- Domain factories are now generated inside the domain layer under the configured factory namespace `ddd.namespaces.factory` (default `Database\Factories`). Factories located in `/database/factories/<domain>/*` (v0.x) will continue to work as a fallback when attempting to resolve a domain model's factory.
+- Minimum supported Laravel version is now 10.25.
 
 ### Chore
 - Dropped Laravel 9 support.

--- a/src/Commands/DomainFactoryMakeCommand.php
+++ b/src/Commands/DomainFactoryMakeCommand.php
@@ -2,7 +2,6 @@
 
 namespace Lunarstorm\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Support\Path;
 use Symfony\Component\Console\Input\InputOption;
 
 class DomainFactoryMakeCommand extends DomainGeneratorCommand
@@ -31,37 +30,13 @@ class DomainFactoryMakeCommand extends DomainGeneratorCommand
         return $this->resolveStubPath('factory.php.stub');
     }
 
-    protected function rootNamespace()
-    {
-        return 'Database\\Factories\\';
-    }
-
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        $domain = $this->domain?->domainWithSubdomain;
-
-        return $rootNamespace.'\\'.$domain;
-    }
-
-    protected function getRelativeDomainNamespace(): string
-    {
-        return '';
-    }
-
     protected function getPath($name)
     {
         if (! str_ends_with($name, 'Factory')) {
             $name .= 'Factory';
         }
 
-        $name = str($name)
-            ->replaceFirst($this->rootNamespace(), '')
-            ->replace('\\', '/')
-            ->ltrim('/')
-            ->append('.php')
-            ->toString();
-
-        return Path::normalize(base_path('database/factories/'.$name));
+        return parent::getPath($name);
     }
 
     protected function getFactoryName()

--- a/src/Support/Domain.php
+++ b/src/Support/Domain.php
@@ -122,18 +122,7 @@ class Domain
 
     public function factory(string $name): DomainObject
     {
-        $name = str($name)->replace($this->namespace->root, '')->toString();
-
-        return new DomainObject(
-            name: $name,
-            domain: $this->domain,
-            namespace: $this->namespace->factories,
-            fullyQualifiedName: $this->namespace->factories.'\\'.$name,
-            path: str("database/factories/{$this->domainWithSubdomain}/{$name}.php")
-                ->replace(['\\', '/'], DIRECTORY_SEPARATOR)
-                ->toString(),
-            type: 'factory'
-        );
+        return $this->object('factory', $name);
     }
 
     public function dataTransferObject(string $name): DomainObject

--- a/tests/Factory/DomainFactoryTest.php
+++ b/tests/Factory/DomainFactoryTest.php
@@ -6,11 +6,23 @@ use Illuminate\Support\Facades\Config;
 use Lunarstorm\LaravelDDD\Factories\DomainFactory;
 
 it('can resolve the factory name of a domain model', function ($modelClass, $expectedFactoryClass) {
+    $this->setupTestApplication();
+
     expect(DomainFactory::resolveFactoryName($modelClass))->toBe($expectedFactoryClass);
 })->with([
-    ["Domain\Customer\Models\Invoice", "Database\Factories\Customer\InvoiceFactory"],
-    ["Domain\Reports\Accounting\Models\InvoiceReport", "Database\Factories\Reports\Accounting\InvoiceReportFactory"],
+    ["Domain\Invoicing\Models\Invoice", "Domain\Invoicing\Database\Factories\InvoiceFactory"],
+    ["Domain\Invoicing\Models\VanillaModel", "Domain\Invoicing\Database\Factories\VanillaModelFactory"],
     ["App\Models\Invoice", null],
+]);
+
+it('is backwards compatible with factories located in database/factories/**/*', function ($modelClass, $expectedFactoryClass) {
+    $this->setupTestApplication();
+
+    expect(DomainFactory::resolveFactoryName($modelClass))->toBe($expectedFactoryClass);
+})->with([
+    ["Domain\Customer\Models\Customer", "Database\Factories\Customer\CustomerFactory"],
+    ["Domain\Reports\Accounting\Models\InvoiceReport", "Database\Factories\Reports\Accounting\InvoiceReportFactory"],
+    ["Domain\Invoicing\Models\Payment", "Database\Factories\Invoicing\PaymentFactory"],
 ]);
 
 it('can instantiate a domain model factory', function ($domainParameter, $modelName, $modelClass) {

--- a/tests/Support/DomainTest.php
+++ b/tests/Support/DomainTest.php
@@ -36,8 +36,8 @@ it('can describe a domain factory', function ($domainName, $name, $expectedFQN, 
         ->fullyQualifiedName->toBe($expectedFQN)
         ->path->toBe(Path::normalize($expectedPath));
 })->with([
-    ['Reporting', 'InvoiceReportFactory', 'Database\\Factories\\Reporting\\InvoiceReportFactory', 'database/factories/Reporting/InvoiceReportFactory.php'],
-    ['Reporting.Internal', 'InvoiceReportFactory', 'Database\\Factories\\Reporting\\Internal\\InvoiceReportFactory', 'database/factories/Reporting/Internal/InvoiceReportFactory.php'],
+    ['Reporting', 'InvoiceReportFactory', 'Domain\\Reporting\\Database\\Factories\\InvoiceReportFactory', 'src/Domain/Reporting/Database/Factories/InvoiceReportFactory.php'],
+    ['Reporting.Internal', 'InvoiceReportFactory', 'Domain\\Reporting\\Internal\\Database\\Factories\\InvoiceReportFactory', 'src/Domain/Reporting/Internal/Database/Factories/InvoiceReportFactory.php'],
 ]);
 
 it('can describe a data transfer object', function ($domainName, $name, $expectedFQN, $expectedPath) {


### PR DESCRIPTION
Generate factories in the domain layer according to `ddd.namespaces.factory`, while maintaining backwards compatibility with factories previously generated under `database/factories/**/*`.