### PR TITLE
54 additional laravel 11 generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ php artisan ddd:provider Invoicing:InvoiceServiceProvider
 php artisan ddd:provider Invoicing:/InvoiceServiceProvider
 # -> Domain\Invoicing\InvoiceServiceProvider
 
-# Generate 
-php artisan ddd:provider Invoicing:/InvoiceServiceProvider
-# -> Domain\Invoicing\InvoiceServiceProvider
+# Generate an event inside the Models namespace (hypothetical)
+php artisan ddd:event Invoicing:/Models/EventDoesNotBelongHere
+# -> Domain\Invoicing\Models\EventDoesNotBelongHere
 
 # Deep nesting is supported
 php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,24 @@ All notable changes to `laravel-ddd` will be documented in this file.
 - Add `ddd:trait` generator extending Laravel's `make:trait` (Laravel 11 only).
 - Allow overriding configured namespaces at runtime by specifying an absolute name starting with /:
 ```bash
-# Generate a provider in the default configured namespace
-# -> Domain\Invoicing\Providers\InvoiceServiceProvider
+# The usual: generate a provider in the configured provider namespace
 php artisan ddd:provider Invoicing:InvoiceServiceProvider 
+# -> Domain\Invoicing\Providers\InvoiceServiceProvider
 
 # Override the configured namespace at runtime
-# -> Domain\Invoicing\InvoiceServiceProvider
 php artisan ddd:provider Invoicing:/InvoiceServiceProvider
+# -> Domain\Invoicing\InvoiceServiceProvider
 
-# Can be deeply nested if desired
-# -> Domain\Invoicing\Models\Exceptions\InvoiceNotFoundException
+# Generate 
+php artisan ddd:provider Invoicing:/InvoiceServiceProvider
+# -> Domain\Invoicing\InvoiceServiceProvider
+
+# Deep nesting is supported
 php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException
+# -> Domain\Invoicing\Models\Exceptions\InvoiceNotFoundException
 ```
 
-### Changed
+### Fixed
 - Internals: Handle a variety of additional edge cases when generating base models and base view models.
 
 ## [1.0.0] - 2024-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [Unversioned]
+### Added
+- Add `ddd:class` generator extending Laravel's `make:class` (Laravel 11 only).
+- Add `ddd:interface` generator extending Laravel's `make:interface` (Laravel 11 only).
+- Add `ddd:trait` generator extending Laravel's `make:trait` (Laravel 11 only).
+- Allow overriding configured namespaces at runtime by specifying an absolute name starting with /:
+```bash
+# Generate a provider in the default configured namespace
+# -> Domain\Invoicing\Providers\InvoiceServiceProvider
+php artisan ddd:provider Invoicing:InvoiceServiceProvider 
+
+# Override the configured namespace at runtime
+# -> Domain\Invoicing\InvoiceServiceProvider
+php artisan ddd:provider Invoicing:/InvoiceServiceProvider
+
+# Can be deeply nested if desired
+# -> Domain\Invoicing\Models\Exceptions\InvoiceNotFoundException
+php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException
+```
+
+### Changed
+- Internals: Handle a variety of additional edge cases when generating base models and base view models.
+
 ## [1.0.0] - 2024-03-31
 ### Added
 - `ddd:list` to show a summary of current domains in the domain folder.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,16 @@ php artisan ddd:cache
 ```
 
 ### Version Compatibility
- Laravel        | LaravelDDD |  Notes                                                                               |
+ Laravel        | LaravelDDD |                                                                                      |
 :---------------|:-----------|:-------------------------------------------------------------------------------------|
  9.x - 10.24.x  | 0.x        | **[0.x README](https://github.com/lunarstorm/laravel-ddd/blob/v0.10.0/README.md)**   |
  10.25.x        | 1.x        |  
  11.x           | 1.x        |
 
 ### Upgrading from 0.x
-Things to be aware of when upgrading from 0.x:
-- Re-publish and update config. A helper command `ddd:upgrade` is available to assist with this.
+- Update config to the [latest format](#config-file). A helper command `ddd:upgrade` is available to assist with this.
 - Remove and re-publish stubs if applicable.
-- In production, `ddd:cache` should be run during the deployment process to optimize autoloading. See the [Autoloading in Production](#autoloading-in-production) section for more details.
+- In production, `ddd:cache` should be run during the deployment process. See the [Autoloading in Production](#autoloading-in-production) section for more details.
 
 ## Usage
 ### Syntax
@@ -178,7 +177,6 @@ In production, you should cache the autoload manifests using the `ddd:cache` com
 This is the content of the published config file (`ddd.php`):
 
 ```php
-
 return [
 
     /*
@@ -224,12 +222,14 @@ return [
         'value_object' => 'ValueObjects',
         'action' => 'Actions',
         'cast' => 'Casts',
+        'class' => '',
         'channel' => 'Channels',
         'command' => 'Commands',
         'enum' => 'Enums',
         'event' => 'Events',
         'exception' => 'Exceptions',
         'factory' => 'Database\Factories',
+        'interface' => '',
         'job' => 'Jobs',
         'listener' => 'Listeners',
         'mail' => 'Mail',
@@ -240,6 +240,7 @@ return [
         'resource' => 'Resources',
         'rule' => 'Rules',
         'scope' => 'Scopes',
+        'trait' => '',
     ],
 
     /*
@@ -302,26 +303,30 @@ return [
     */
     'autoload' => [
         /**
-         * When enabled, any class within the domain layer extending `Illuminate\Support\ServiceProvider`
-         * will be auto-registered as a service provider
+         * When enabled, any class in the domain layer extending 
+         * `Illuminate\Support\ServiceProvider` will be 
+         * auto-registered as a service provider
          */
         'providers' => true,
 
         /**
-         * When enabled, any class within the domain layer extending `Illuminate\Console\Command`
-         * will be auto-registered as a command when running in console.
+         * When enabled, any class in the domain layer extending 
+         * `Illuminate\Console\Command` will be auto-registered 
+         * as a command when running in console.
          */
         'commands' => true,
 
         /**
-         * When enabled, the package will register a custom policy discovery callback to resolve policy names
-         * for domain models, and fallback to Laravel's default for all other cases.
+         * When enabled, a custom policy discovery callback will be
+         * registered to resolve policy names for domain models, 
+         * or fallback to Laravel's default otherwise.
          */
         'policies' => true,
 
         /**
-         * When enabled, the package will register a custom factory discovery callback to resolve factory names
-         * for domain models, and fallback to Laravel's default for all other cases.
+         * When enabled, a custom policy discovery callback will be
+         * registered to resolve factory names for domain models, 
+         * or fallback to Laravel's default otherwise.
          */
         'factories' => true,
     ],

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ php artisan ddd:provider Invoicing:InvoiceServiceProvider
 php artisan ddd:provider Invoicing:/InvoiceServiceProvider
 # -> Domain\Invoicing\InvoiceServiceProvider
 
-# Generate 
-php artisan ddd:provider Invoicing:/InvoiceServiceProvider
-# -> Domain\Invoicing\InvoiceServiceProvider
+# Generate an event inside the Models namespace (hypothetical)
+php artisan ddd:event Invoicing:/Models/EventDoesNotBelongHere
+# -> Domain\Invoicing\Models\EventDoesNotBelongHere
 
 # Deep nesting is supported
 php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException

--- a/README.md
+++ b/README.md
@@ -14,25 +14,28 @@ You can install the package via composer:
 composer require lunarstorm/laravel-ddd
 ```
 
-You may then initialize the package using the `ddd:install` artisan command. This command will publish the config file, register the domain path in your project's composer.json psr-4 autoload configuration on your behalf, and allow you to publish generator stubs for customization if needed.
+You may initialize the package using the `ddd:install` artisan command. This will publish the config file, register the domain path in your project's composer.json psr-4 autoload configuration on your behalf, and allow you to publish generator stubs for customization if needed.
 ```bash
 php artisan ddd:install
 ```
 
-### Version Compatibility
- Laravel        | LaravelDDD 
-:---------------|:-----------
- 9.x - 10.24.x  | 0.x        
- 10.25.x        | 1.x 
- 11.x           | 1.x
+### Deployment
+In production, run `ddd:cache` during the deployment process to optimize autoloading. See the [Autoloading in Production](#autoloading-in-production) section for more details.
+```bash
+php artisan ddd:cache
+```
 
-> For 0.x usage, please refer to the **[0.x README](https://github.com/lunarstorm/laravel-ddd/blob/v0.10.0/README.md)**.
->
+### Version Compatibility
+ Laravel        | LaravelDDD |  Notes                                                                               |
+:---------------|:-----------|:-------------------------------------------------------------------------------------|
+ 9.x - 10.24.x  | 0.x        | **[0.x README](https://github.com/lunarstorm/laravel-ddd/blob/v0.10.0/README.md)**   |
+ 10.25.x        | 1.x        |  
+ 11.x           | 1.x        |
 
 ### Upgrading from 0.x
 Things to be aware of when upgrading from 0.x:
-- If the config file was published, it should be removed, re-published, and re-configured according to the latest format. A helper command `ddd:upgrade` is available to assist with this.
-- If stubs were published, they should also be re-published and inspected to ensure everything is up-to-date.
+- Re-publish and update config. A helper command `ddd:upgrade` is available to assist with this.
+- Remove and re-publish stubs if applicable.
 - In production, `ddd:cache` should be run during the deployment process to optimize autoloading. See the [Autoloading in Production](#autoloading-in-production) section for more details.
 
 ## Usage
@@ -110,7 +113,7 @@ php artisan ddd:cache
 php artisan ddd:clear
 ```
 
-### Subdomains (nested domains)
+## Subdomains (nested domains)
 Subdomains can be specified with dot notation wherever a domain option is accepted.
 ```bash
 # Domain/Reporting/Internal/ViewModels/MonthlyInvoicesReportViewModel
@@ -122,7 +125,7 @@ php artisan ddd:view-model Reporting.Customer:MonthlyInvoicesReportViewModel
 # (supported by all commands where a domain option is accepted)
 ```
 
-### Customization
+## Customization
 This package ships with opinionated (but sensible) configuration defaults. You may customize by publishing the config file and generator stubs as needed:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ php artisan ddd:action Invoicing:SendInvoiceToCustomer
 php artisan ddd:cast Invoicing:MoneyCast
 php artisan ddd:channel Invoicing:InvoiceChannel
 php artisan ddd:command Invoicing:InvoiceDeliver
-php artisan ddd:enum Customer:CustomerType # Laravel 11+ only
 php artisan ddd:event Invoicing:PaymentWasReceived
 php artisan ddd:exception Invoicing:InvoiceNotFoundException
 php artisan ddd:job Invoicing:GenerateInvoicePdf
@@ -97,6 +96,12 @@ php artisan ddd:provider Invoicing:InvoiceServiceProvider
 php artisan ddd:resource Invoicing:InvoiceResource
 php artisan ddd:rule Invoicing:ValidPaymentMethod
 php artisan ddd:scope Invoicing:ArchivedInvoicesScope
+
+# Laravel 11+ only
+php artisan ddd:class Invoicing:Support\InvoiceBuilder
+php artisan ddd:enum Customer:CustomerType
+php artisan ddd:interface Customer:Contracts\Invoiceable
+php artisan ddd:trait Customer:Concerns\HasInvoices
 ```
 Generated objects will be placed in the appropriate domain namespace as specified by `ddd.namespaces.*` in the configuration file.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ php artisan ddd:install
 ```
 
 ### Deployment
-In production, run `ddd:cache` during the deployment process to optimize autoloading. See the [Autoloading in Production](#autoloading-in-production) section for more details.
+In production, run `ddd:cache` during the deployment process to [optimize autoloading](#autoloading-in-production).
 ```bash
 php artisan ddd:cache
 ```

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ php artisan ddd:rule Invoicing:ValidPaymentMethod
 php artisan ddd:scope Invoicing:ArchivedInvoicesScope
 
 # Laravel 11+ only
-php artisan ddd:class Invoicing:Support\InvoiceBuilder
+php artisan ddd:class Invoicing:Support/InvoiceBuilder
 php artisan ddd:enum Customer:CustomerType
-php artisan ddd:interface Customer:Contracts\Invoiceable
-php artisan ddd:trait Customer:Concerns\HasInvoices
+php artisan ddd:interface Customer:Contracts/Invoiceable
+php artisan ddd:trait Customer:Concerns/HasInvoices
 ```
 Generated objects will be placed in the appropriate domain namespace as specified by `ddd.namespaces.*` in the configuration file.
 
@@ -117,7 +117,55 @@ php artisan ddd:cache
 php artisan ddd:clear
 ```
 
-## Subdomains (nested domains)
+## Advanced Usage
+### Nested Objects
+When specifying object names for any `ddd:*` generator command, nested objects can be specified with forward slashes.
+```bash
+php artisan ddd:model Invoicing:Payment/Transaction
+# -> Domain\Invoicing\Models\Payment\Transaction
+
+php artisan ddd:action Invoicing:Payment/ProcessTransaction
+# -> Domain\Invoicing\Actions\Payment\ProcessTransaction
+
+php artisan ddd:exception Invoicing:Payment/PaymentFailedException
+# -> Domain\Invoicing\Exceptions\Payment\PaymentFailedException
+```
+This is essential for objects without a fixed namespace such as `class`, `interface`, `trait`, 
+each of which have a blank namespace by default. In other words, these objects originate 
+from the root of the domain.
+```bash
+php artisan ddd:class Invoicing:Support/InvoiceBuilder
+# -> Domain\Invoicing\Support\InvoiceBuilder
+
+php artisan ddd:interface Invoicing:Contracts/PayableByCreditCard
+# -> Domain\Invoicing\Contracts\PayableByCreditCard
+
+php artisan ddd:interface Invoicing:Models/Concerns/HasLineItems
+# -> Domain\Invoicing\Models\Concerns\HasLineItems
+```
+
+### Overriding Configured Namespaces at Runtime
+If for some reason you need to generate a domain object under a namespace different to what is configured in `ddd.namespaces.*`,
+you may do so using an absolute name starting with `/`. This will generate the object from the root of the domain.
+```bash
+# The usual: generate a provider in the configured provider namespace
+php artisan ddd:provider Invoicing:InvoiceServiceProvider 
+# -> Domain\Invoicing\Providers\InvoiceServiceProvider
+
+# Override the configured namespace at runtime
+php artisan ddd:provider Invoicing:/InvoiceServiceProvider
+# -> Domain\Invoicing\InvoiceServiceProvider
+
+# Generate 
+php artisan ddd:provider Invoicing:/InvoiceServiceProvider
+# -> Domain\Invoicing\InvoiceServiceProvider
+
+# Deep nesting is supported
+php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException
+# -> Domain\Invoicing\Models\Exceptions\InvoiceNotFoundException
+```
+
+### Subdomains (nested domains)
 Subdomains can be specified with dot notation wherever a domain option is accepted.
 ```bash
 # Domain/Reporting/Internal/ViewModels/MonthlyInvoicesReportViewModel

--- a/config/ddd.php
+++ b/config/ddd.php
@@ -45,12 +45,14 @@ return [
         'value_object' => 'ValueObjects',
         'action' => 'Actions',
         'cast' => 'Casts',
+        'class' => '',
         'channel' => 'Channels',
         'command' => 'Commands',
         'enum' => 'Enums',
         'event' => 'Events',
         'exception' => 'Exceptions',
         'factory' => 'Database\Factories',
+        'interface' => '',
         'job' => 'Jobs',
         'listener' => 'Listeners',
         'mail' => 'Mail',
@@ -61,6 +63,7 @@ return [
         'resource' => 'Resources',
         'rule' => 'Rules',
         'scope' => 'Scopes',
+        'trait' => '',
     ],
 
     /*

--- a/src/Commands/DomainClassMakeCommand.php
+++ b/src/Commands/DomainClassMakeCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Commands;
+
+use Illuminate\Foundation\Console\ClassMakeCommand;
+use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+
+class DomainClassMakeCommand extends ClassMakeCommand
+{
+    use ResolvesDomainFromInput;
+
+    protected $name = 'ddd:class';
+}

--- a/src/Commands/DomainInterfaceMakeCommand.php
+++ b/src/Commands/DomainInterfaceMakeCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Commands;
+
+use Illuminate\Foundation\Console\InterfaceMakeCommand;
+use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+
+class DomainInterfaceMakeCommand extends InterfaceMakeCommand
+{
+    use ResolvesDomainFromInput;
+
+    protected $name = 'ddd:interface';
+}

--- a/src/Commands/DomainTraitMakeCommand.php
+++ b/src/Commands/DomainTraitMakeCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Commands;
+
+use Illuminate\Foundation\Console\TraitMakeCommand;
+use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+
+class DomainTraitMakeCommand extends TraitMakeCommand
+{
+    use ResolvesDomainFromInput;
+
+    protected $name = 'ddd:trait';
+}

--- a/src/Commands/DomainViewModelMakeCommand.php
+++ b/src/Commands/DomainViewModelMakeCommand.php
@@ -52,7 +52,7 @@ class DomainViewModelMakeCommand extends DomainGeneratorCommand
 
             $domain = DomainResolver::guessDomainFromClass($baseViewModel);
 
-            $name = Str::after($baseViewModel, "{$domain}\\");
+            $name = Str::after($baseViewModel, $domain);
 
             $this->call(DomainBaseViewModelMakeCommand::class, [
                 '--domain' => $domain,

--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -51,9 +51,11 @@ class LaravelDDDServiceProvider extends PackageServiceProvider
                 Commands\DomainScopeMakeCommand::class,
             ]);
 
-        // Enum generator only in Laravel 11
         if (app()->version() >= 11) {
-            $package->hasCommand(\Lunarstorm\LaravelDDD\Commands\DomainEnumMakeCommand::class);
+            $package->hasCommand(Commands\DomainClassMakeCommand::class);
+            $package->hasCommand(Commands\DomainEnumMakeCommand::class);
+            $package->hasCommand(Commands\DomainInterfaceMakeCommand::class);
+            $package->hasCommand(Commands\DomainTraitMakeCommand::class);
         }
     }
 

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -47,7 +47,11 @@ class DomainResolver
 
     public static function getDomainObjectNamespace(string $domain, string $type, ?string $object = null): string
     {
-        $namespace = implode('\\', [static::domainRootNamespace(), $domain, static::getRelativeObjectNamespace($type)]);
+        $namespace = collect([
+            static::domainRootNamespace(),
+            $domain,
+            static::getRelativeObjectNamespace($type),
+        ])->filter()->implode('\\');
 
         if ($object) {
             $namespace .= "\\{$object}";

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Lunarstorm\LaravelDDD\Support\Path;
 
 use function PHPUnit\Framework\assertMatchesRegularExpression;
@@ -12,4 +13,28 @@ expect()->extend('toMatchRegularExpression', function ($pattern, string $message
 
 expect()->extend('toContainFilepath', function ($path) {
     return $this->toContain(Path::normalize($path));
+});
+
+expect()->extend('toGenerateFileWithNamespace', function ($expectedPath, $expectedNamespace) {
+    $command = $this->value;
+
+    $expectedFullPath = Path::normalize(base_path($expectedPath));
+
+    if (file_exists($expectedFullPath)) {
+        unlink($expectedFullPath);
+    }
+
+    Artisan::call($command);
+
+    $output = Artisan::output();
+
+    expect($output)->toContainFilepath($expectedPath);
+
+    expect(file_exists($expectedFullPath))->toBeTrue();
+
+    $contents = file_get_contents($expectedFullPath);
+
+    expect($contents)->toContain("namespace {$expectedNamespace};");
+
+    return $this;
 });

--- a/tests/Generator/AbsoluteNameTest.php
+++ b/tests/Generator/AbsoluteNameTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
+use Lunarstorm\LaravelDDD\Support\Path;
+
+it('can override configured object namespace by using absolute dot-path', function ($type, $nameInput, $expectedNamespace, $expectedPath) {
+    if (in_array($type, ['class', 'enum', 'interface', 'trait'])) {
+        skipOnLaravelVersionsBelow('11');
+    }
+
+    $domainPath = 'src/Domain';
+    $domainRoot = 'Domain';
+
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
+    Config::set("ddd.namespaces.{$type}", str($type)->headline()->plural()->toString());
+
+    $expectedFullPath = Path::normalize(base_path($expectedPath));
+
+    if (file_exists($expectedFullPath)) {
+        unlink($expectedFullPath);
+    }
+
+    expect(file_exists($expectedFullPath))->toBeFalse();
+
+    $command = "ddd:{$type} {$nameInput}";
+
+    Artisan::call($command);
+
+    $output = Artisan::output();
+
+    expect($output)->toContainFilepath($expectedPath);
+
+    expect(file_exists($expectedFullPath))->toBeTrue();
+
+    $contents = file_get_contents($expectedFullPath);
+
+    expect($contents)->toContain("namespace {$expectedNamespace};");
+})->with([
+    'model' => ['model', 'Other:/MyModels/MyModel', 'Domain\Other\MyModels', 'src/Domain/Other/MyModels/MyModel.php'],
+    'model (without overriding)' => ['model', 'Other:MyModels/MyModel', 'Domain\Other\Models\MyModels', 'src/Domain/Other/Models/MyModels/MyModel.php'],
+    'exception inside models directory' => ['exception', 'Invoicing:/Models/Exceptions/InvoiceNotFoundException', 'Domain\Invoicing\Models\Exceptions', 'src/Domain/Invoicing/Models/Exceptions/InvoiceNotFoundException.php'],
+    'provider' => ['provider', 'Other:/RootLevelProvider', 'Domain\Other', 'src/Domain/Other/RootLevelProvider.php'],
+    'policy' => ['policy', 'Other:/RootLevelPolicy', 'Domain\Other', 'src/Domain/Other/RootLevelPolicy.php'],
+    'job' => ['job', 'Other:/Custom/Namespaced/Job', 'Domain\Other\Custom\Namespaced', 'src/Domain/Other/Custom/Namespaced/Job.php'],
+    'class' => ['class', 'Other:/Models/FakeModel', 'Domain\Other\Models', 'src/Domain/Other/Models/FakeModel.php'],
+    'class (subdomain)' => ['class', 'Other.Subdomain:/Models/FakeModel', 'Domain\Other\Subdomain\Models', 'src/Domain/Other/Subdomain/Models/FakeModel.php'],
+    'provider (subdomain)' => ['provider', 'Other.Subdomain:/RootLevelProvider', 'Domain\Other\Subdomain', 'src/Domain/Other/Subdomain/RootLevelProvider.php'],
+]);

--- a/tests/Generator/ExtendedCommandsTest.php
+++ b/tests/Generator/ExtendedCommandsTest.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Config;
 use Lunarstorm\LaravelDDD\Support\Domain;
 
 it('can generate extended objects', function ($type, $objectName, $domainPath, $domainRoot) {
-    if (in_array($type, ['enum'])) {
+    if (in_array($type, ['class', 'enum', 'interface', 'trait'])) {
         skipOnLaravelVersionsBelow('11');
     }
 
@@ -38,7 +38,6 @@ it('can generate extended objects', function ($type, $objectName, $domainPath, $
     'cast' => ['cast', 'SomeCast'],
     'channel' => ['channel', 'SomeChannel'],
     'command' => ['command', 'SomeCommand'],
-    'enum' => ['enum', 'SomeEnum'],
     'event' => ['event', 'SomeEvent'],
     'exception' => ['exception', 'SomeException'],
     'job' => ['job', 'SomeJob'],
@@ -51,4 +50,8 @@ it('can generate extended objects', function ($type, $objectName, $domainPath, $
     'resource' => ['resource', 'SomeResource'],
     'rule' => ['rule', 'SomeRule'],
     'scope' => ['scope', 'SomeScope'],
+    'class' => ['class', 'SomeClass'],
+    'enum' => ['enum', 'SomeEnum'],
+    'interface' => ['interface', 'SomeInterface'],
+    'trait' => ['trait', 'SomeTrait'],
 ])->with('domainPaths');

--- a/tests/Generator/MakeModelTest.php
+++ b/tests/Generator/MakeModelTest.php
@@ -149,6 +149,7 @@ it('generates the base model when possible', function ($baseModelClass, $baseMod
 })->with([
     ['Domain\Shared\Models\CustomBaseModel', 'src/Domain/Shared/Models/CustomBaseModel.php'],
     ['Domain\Core\Models\CustomBaseModel', 'src/Domain/Core/Models/CustomBaseModel.php'],
+    ['Domain\Core\BaseModels\CustomBaseModel', 'src/Domain/Core/BaseModels/CustomBaseModel.php'],
 ]);
 
 it('will not generate a base model if the configured base model is out of scope', function ($baseModel) {
@@ -158,9 +159,7 @@ it('will not generate a base model if the configured base model is out of scope'
 
     Artisan::call('ddd:model Fruits:Lemon');
 
-    expect(Artisan::output())
-        ->toContain("Configured base model {$baseModel} doesn't exist.")
-        ->not->toContain("Generating {$baseModel}");
+    expect(Artisan::output())->not->toContain("Configured base model {$baseModel} doesn't exist, generating...");
 
     expect(class_exists($baseModel))->toBeFalse();
 })->with([
@@ -175,9 +174,7 @@ it('skips base model creation if configured base model already exists', function
 
     Artisan::call('ddd:model Fruits:Lemon');
 
-    expect(Artisan::output())
-        ->not->toContain("Configured base model {$baseModel} doesn't exist.")
-        ->not->toContain("Generating {$baseModel}");
+    expect(Artisan::output())->not->toContain("Configured base model {$baseModel} doesn't exist, generating...");
 })->with([
     ['Illuminate\Database\Eloquent\Model'],
     ['Lunarstorm\LaravelDDD\Models\DomainModel'],

--- a/tests/Generator/MakeViewModelTest.php
+++ b/tests/Generator/MakeViewModelTest.php
@@ -103,7 +103,11 @@ it('generates the base view model if needed', function ($baseViewModel, $baseVie
 
     Artisan::call("ddd:view-model {$domain}:{$className}");
 
-    expect(Artisan::output())->toContain("Base view model {$baseViewModel} doesn't exist, generating");
+    $output = Artisan::output();
+
+    dump($output);
+
+    expect($output)->toContain("Base view model {$baseViewModel} doesn't exist, generating");
 
     expect(file_exists($expectedBaseViewModelPath))->toBeTrue();
 

--- a/tests/Generator/NestedNameTest.php
+++ b/tests/Generator/NestedNameTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+
+it('can generate nested objects', function ($type, $configuredNamespace, $nameInput, $expectedNamespace, $expectedPath) {
+    if (in_array($type, ['class', 'enum', 'interface', 'trait'])) {
+        skipOnLaravelVersionsBelow('11');
+    }
+
+    $domainPath = 'src/Domain';
+    $domainRoot = 'Domain';
+
+    Config::set('ddd.domain_path', $domainPath);
+    Config::set('ddd.domain_namespace', $domainRoot);
+    Config::set("ddd.namespaces.{$type}", $configuredNamespace);
+
+    $slug = Str::slug($type);
+
+    $command = "ddd:{$slug} {$nameInput}";
+
+    expect($command)->toGenerateFileWithNamespace($expectedPath, $expectedNamespace);
+})->with([
+    'model Invoicing:Deep/Nested/Model' => ['model', 'Models', 'Invoicing:Deep/Nested/Model', 'Domain\Invoicing\Models\Deep\Nested', 'src/Domain/Invoicing/Models/Deep/Nested/Model.php'],
+    'action Invoicing:Deep/Nested/SomeAction' => ['action', 'Actions', 'Invoicing:Deep/Nested/SomeAction', 'Domain\Invoicing\Actions\Deep\Nested', 'src/Domain/Invoicing/Actions/Deep/Nested/SomeAction.php'],
+    'dto Invoicing:Deep/Nested/InvoiceData' => ['dto', 'Data', 'Invoicing:Deep/Nested/InvoiceData', 'Domain\Invoicing\Data\Deep\Nested', 'src/Domain/Invoicing/Data/Deep/Nested/InvoiceData.php'],
+    'view_model Invoicing:Deep/Nested/InvoiceViewModel' => ['view_model', 'ViewModels', 'Invoicing:Deep/Nested/InvoiceViewModel', 'Domain\Invoicing\ViewModels\Deep\Nested', 'src/Domain/Invoicing/ViewModels/Deep/Nested/InvoiceViewModel.php'],
+    'value_object Invoicing:Deep/Nested/InvoiceNumber' => ['value_object', 'ValueObjects', 'Invoicing:Deep/Nested/InvoiceNumber', 'Domain\Invoicing\ValueObjects\Deep\Nested', 'src/Domain/Invoicing/ValueObjects/Deep/Nested/InvoiceNumber.php'],
+    'provider Invoicing:Deep/Nested/InvoiceProvider' => ['provider', 'Providers', 'Invoicing:Deep/Nested/InvoiceProvider', 'Domain\Invoicing\Providers\Deep\Nested', 'src/Domain/Invoicing/Providers/Deep/Nested/InvoiceProvider.php'],
+    'exception Deep/Nested/InvoiceNotFoundException' => ['exception', 'Exceptions', 'Invoicing:Deep/Nested/InvoiceNotFoundException', 'Domain\Invoicing\Exceptions\Deep\Nested', 'src/Domain/Invoicing/Exceptions/Deep/Nested/InvoiceNotFoundException.php'],
+    'cast Invoicing:Deep/Nested/InvoiceCast' => ['cast', 'Casts', 'Invoicing:Deep/Nested/InvoiceCast', 'Domain\Invoicing\Casts\Deep\Nested', 'src/Domain/Invoicing/Casts/Deep/Nested/InvoiceCast.php'],
+    'channel Invoicing:Deep/Nested/InvoiceChannel' => ['channel', 'Channels', 'Invoicing:Deep/Nested/InvoiceChannel', 'Domain\Invoicing\Channels\Deep\Nested', 'src/Domain/Invoicing/Channels/Deep/Nested/InvoiceChannel.php'],
+    'command Invoicing:Deep/Nested/InvoiceCommand' => ['command', 'Commands', 'Invoicing:Deep/Nested/InvoiceCommand', 'Domain\Invoicing\Commands\Deep\Nested', 'src/Domain/Invoicing/Commands/Deep/Nested/InvoiceCommand.php'],
+    'class Invoicing:Deep/Nested/InvoiceClass' => ['class', '', 'Invoicing:Deep/Nested/InvoiceClass', 'Domain\Invoicing\Deep\Nested', 'src/Domain/Invoicing/Deep/Nested/InvoiceClass.php'],
+]);

--- a/tests/ValueObject/DomainObjectTest.php
+++ b/tests/ValueObject/DomainObjectTest.php
@@ -15,16 +15,65 @@ it('can create a domain object from resolvable class names', function (string $c
         ->namespace->toEqual($relativeNamespace)
         ->path->toEqual($expectedPath);
 })->with([
-    ['Domain\Invoicing\Models\Invoice', 'Invoicing', 'Models', 'Invoice'],
-    ['Domain\Invoicing\Models\Payment\InvoicePayment', 'Invoicing', 'Models\Payment', 'InvoicePayment'],
-    ['Domain\Internal\Invoicing\Models\Invoice', 'Internal\Invoicing', 'Models', 'Invoice'],
-    ['Domain\Internal\Invoicing\Models\Payment\InvoicePayment', 'Internal\Invoicing', 'Models\Payment', 'InvoicePayment'],
-    ['Domain\Invoicing\AdHoc\Thing', 'Invoicing', 'AdHoc', 'Thing'],
-    ['Domain\Invoicing\AdHoc\Nested\Thing', 'Invoicing', 'AdHoc\Nested', 'Thing'],
+    [
+        // Full Class Name
+        'Domain\Invoicing\Models\Invoice',
+
+        // Domain
+        'Invoicing',
+
+        // Object Namespace
+        'Models',
+
+        // Object Name
+        'Invoice',
+    ],
+
+    [
+        'Domain\Invoicing\Models\Payment\InvoicePayment',
+        'Invoicing',
+        'Models',
+        'Payment\InvoicePayment',
+    ],
+
+    [
+        'Domain\Internal\Invoicing\Models\Invoice',
+        'Internal\Invoicing',
+        'Models',
+        'Invoice',
+    ],
+
+    [
+        'Domain\Internal\Invoicing\Models\Payment\InvoicePayment',
+        'Internal\Invoicing',
+        'Models',
+        'Payment\InvoicePayment',
+    ],
+
+    [
+        'Domain\Invoicing\AdHoc\Thing',
+        'Invoicing',
+        '',
+        'AdHoc\Thing',
+    ],
+
+    [
+        'Domain\Invoicing\AdHoc\Nested\Thing',
+        'Invoicing',
+        '',
+        'AdHoc\Nested\Thing',
+    ],
+
+    [
+        'Domain\Invoicing\InvoicingServiceProvider',
+        'Invoicing',
+        '',
+        'InvoicingServiceProvider',
+    ],
 
     // Ad-hoc objects inside subdomains are not supported for now
-    // ['Domain\Internal\Invoicing\AdHoc\Thing', 'Internal\Invoicing', 'AdHoc', 'Thing'],
-    // ['Domain\Internal\Invoicing\AdHoc\Nested\Thing', 'Internal\Invoicing', 'AdHoc\Nested', 'Thing'],
+    // ['Domain\Internal\Invoicing\AdHoc\Thing', 'Internal\Invoicing', '', 'Adhoc\Thing'],
+    // ['Domain\Internal\Invoicing\Deeply\Nested\Adhoc\Thing', 'Internal\Invoicing', '', 'Deeply\Nested\Adhoc\Thing'],
 ]);
 
 it('cannot create a domain object from unresolvable classes', function (string $class) {


### PR DESCRIPTION
### Added
- Add `ddd:class` generator extending Laravel's `make:class` (Laravel 11 only).
- Add `ddd:interface` generator extending Laravel's `make:interface` (Laravel 11 only).
- Add `ddd:trait` generator extending Laravel's `make:trait` (Laravel 11 only).
- Allow overriding configured namespaces at runtime by specifying an absolute name starting with /:
```bash
# The usual: generate a provider in the configured provider namespace
php artisan ddd:provider Invoicing:InvoiceServiceProvider 
# -> Domain\Invoicing\Providers\InvoiceServiceProvider

# Override the configured namespace at runtime
php artisan ddd:provider Invoicing:/InvoiceServiceProvider
# -> Domain\Invoicing\InvoiceServiceProvider

# Generate an event inside the Models namespace (hypothetical)
php artisan ddd:event Invoicing:/Models/EventDoesNotBelongHere
# -> Domain\Invoicing\Models\EventDoesNotBelongHere

# Deep nesting is supported
php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException
# -> Domain\Invoicing\Models\Exceptions\InvoiceNotFoundException
```

### Fixed
- Internals: Handle a variety of additional edge cases when generating base models and base view models.