### PR TITLE
Resolve get class string instead of an object.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,4 +54,6 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: |
+          composer dump-autoload
+          vendor/bin/pest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,6 +54,4 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: |
-          composer dump-autoload
-          vendor/bin/pest
+        run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,10 @@
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
         "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/pest",
+        "test": [
+            "@composer dump-autoload",
+            "vendor/bin/pest"
+        ],
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint",
         "lint": "vendor/bin/pint"

--- a/src/Support/DomainAutoloader.php
+++ b/src/Support/DomainAutoloader.php
@@ -50,7 +50,7 @@ class DomainAutoloader
     protected static function normalizePaths($path): array
     {
         return collect($path)
-            ->filter(fn ($path) => is_dir($path))
+            ->filter(fn($path) => is_dir($path))
             ->toArray();
     }
 
@@ -99,27 +99,27 @@ class DomainAutoloader
             return Arr::wrap(Collection::times(count($classDirnameSegments), function ($index) use ($class, $classDirnameSegments) {
                 $classDirname = implode('\\', array_slice($classDirnameSegments, 0, $index));
 
-                return $classDirname.'\\Policies\\'.class_basename($class).'Policy';
+                return $classDirname . '\\Policies\\' . class_basename($class) . 'Policy';
             })->reverse()->values()->first(function ($class) {
                 return class_exists($class);
-            }) ?: [$classDirname.'\\Policies\\'.class_basename($class).'Policy']);
+            }) ?: [$classDirname . '\\Policies\\' . class_basename($class) . 'Policy']);
         });
     }
 
     protected function handleFactories(): void
     {
         Factory::guessFactoryNamesUsing(function (string $modelName) {
-            if (DomainResolver::isDomainClass($modelName)) {
-                return DomainFactory::resolveFactoryName($modelName);
+            if ($factoryName = DomainFactory::resolveFactoryName($modelName)) {
+                return $factoryName;
             }
 
             $appNamespace = static::appNamespace();
 
-            $modelName = Str::startsWith($modelName, $appNamespace.'Models\\')
-                ? Str::after($modelName, $appNamespace.'Models\\')
+            $modelName = Str::startsWith($modelName, $appNamespace . 'Models\\')
+                ? Str::after($modelName, $appNamespace . 'Models\\')
                 : Str::after($modelName, $appNamespace);
 
-            return 'Database\\Factories\\'.$modelName.'Factory';
+            return 'Database\\Factories\\' . $modelName . 'Factory';
         });
     }
 
@@ -132,7 +132,7 @@ class DomainAutoloader
                 ->finish('/');
 
             $ignoredFolders = collect(config('ddd.autoload_ignore', []))
-                ->map(fn ($path) => Str::finish($path, '/'));
+                ->map(fn($path) => Str::finish($path, '/'));
 
             if ($pathAfterDomain->startsWith($ignoredFolders)) {
                 return false;

--- a/src/Support/DomainAutoloader.php
+++ b/src/Support/DomainAutoloader.php
@@ -110,7 +110,7 @@ class DomainAutoloader
     {
         Factory::guessFactoryNamesUsing(function (string $modelName) {
             if (DomainResolver::isDomainClass($modelName)) {
-                return DomainFactory::factoryForModel($modelName);
+                return DomainFactory::resolveFactoryName($modelName);
             }
 
             $appNamespace = static::appNamespace();


### PR DESCRIPTION
Resolve get class string instead of an object.
This fix resolve a crash with phpstan or ide-helper

Exemple :
Internal error: class_exists(): Argument #1 ($class) must be of type string, App\Domain\Project\Database\Factories\TaskFactory given while analysing file
     /root/digit/app/Domain/Project/Seeders/TaskSeeder.php