### PR TITLE
Artisan schema dump prune delete ddd migration files

### DIFF
--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -3,7 +3,9 @@
 namespace Lunarstorm\LaravelDDD;
 
 use Illuminate\Database\Migrations\MigrationCreator;
+use Illuminate\Support\Facades\Event;
 use Lunarstorm\LaravelDDD\Facades\Autoload;
+use Lunarstorm\LaravelDDD\Listeners\MigrationsPrunedSubscriber;
 use Lunarstorm\LaravelDDD\Support\AutoloadManager;
 use Lunarstorm\LaravelDDD\Support\DomainMigration;
 use Spatie\LaravelPackageTools\Package;
@@ -139,6 +141,8 @@ class LaravelDDDServiceProvider extends PackageServiceProvider
                 key: 'laravel-ddd',
             );
         }
+
+        Event::subscribe(MigrationsPrunedSubscriber::class);
     }
 
     public function packageRegistered()

--- a/src/Listeners/MigrationsPrunedSubscriber.php
+++ b/src/Listeners/MigrationsPrunedSubscriber.php
@@ -5,6 +5,9 @@ namespace Lunarstorm\LaravelDDD\Listeners;
 use Illuminate\Database\Events\MigrationsPruned;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use SplFileInfo;
 
 class MigrationsPrunedSubscriber
 {
@@ -14,45 +17,45 @@ class MigrationsPrunedSubscriber
     {
         $locations = [
             config('ddd.domain_path'),
-            ...config('ddd.layers')
+            ...config('ddd.layers'),
         ];
 
         $migrationDirs = collect();
+        /** @var Collection<int, SplFileInfo> $filesToDelete */
+        $filesToDelete = collect();
+
+        $filesystem = new Filesystem;
 
         foreach ($locations as $location) {
-            $command = 'find ' . base_path("$location/**/Database") . ' -type d -name "Migrations" 2>/dev/null';
-            // 2>/dev/null at the end is to ignore warnings such as: find: /.../src/Infrastructure/**/Database: No such file or directory
-
-            $result = collect(shell_exec(
-                $command
-            ) ?? []);
-
-            $migrationDirs->push(
-                ...explode(PHP_EOL, $result[0] ?? '')
-            );
-        }
-
-        $migrationDirs = $migrationDirs
-            ->map(static fn (string $dir): string => trim($dir))
-            ->filter(static fn (string $dir): bool => ! empty($dir))
-            ->map(static fn (string $dir): string => str_replace(base_path('/'), '', $dir));
-
-        foreach ($migrationDirs as $dir) {
-            // we could delete the directories, but that could cause damage if a bug happened,
-            // instead we'll just delete php files and only delete the directory afterwards if it is empty
-
-            $filesystem = new Filesystem;
-
-            $files = $filesystem->files($dir);
-
-            foreach ($files as $file) {
-                if ($file->getExtension() == 'php') {
-                    $filesystem->delete("$file");
-                }
+            if (! $filesystem->exists($location)) {
+                continue;
             }
 
-            if ($filesystem->isEmptyDirectory($dir)) {
-                $filesystem->deleteDirectory($dir);
+            $allFiles = $filesystem->allFiles($location);
+
+            foreach ($allFiles as $file) {
+                if (
+                    Str::endsWith($file->getPath(), 'Database/Migrations')
+                    &&
+                    $file->getExtension() == 'php'
+                ) {
+                    $filesToDelete->push($file);
+                }
+            }
+        }
+
+        /** @var Collection<string, Collection<int, SplFileInfo>> $groupedFilesToDelete */
+        $groupedFilesToDelete = $filesToDelete->groupBy(function (SplFileInfo $file) {
+            return $file->getPath();
+        });
+
+        foreach ($groupedFilesToDelete as $location => $groupOfFilesToDelete) {
+            foreach ($groupOfFilesToDelete as $file) {
+                $filesystem->delete($file->getPathname());
+            }
+
+            if ($filesystem->isEmptyDirectory($location)) {
+                $filesystem->deleteDirectory($location);
             }
         }
     }

--- a/src/Listeners/MigrationsPrunedSubscriber.php
+++ b/src/Listeners/MigrationsPrunedSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Lunarstorm\LaravelDDD\Listeners;
+
+use Illuminate\Database\Events\MigrationsPruned;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
+
+class MigrationsPrunedSubscriber
+{
+    public function __construct() {}
+
+    public function handle(): void
+    {
+        $locations = [
+            config('ddd.domain_path'),
+            ...config('ddd.layers')
+        ];
+
+        $migrationDirs = collect();
+
+        foreach ($locations as $location) {
+            $command = 'find ' . base_path("$location/**/Database") . ' -type d -name "Migrations" 2>/dev/null';
+            // 2>/dev/null at the end is to ignore warnings such as: find: /.../src/Infrastructure/**/Database: No such file or directory
+
+            $result = collect(shell_exec(
+                $command
+            ) ?? []);
+
+            $migrationDirs->push(
+                ...explode(PHP_EOL, $result[0] ?? '')
+            );
+        }
+
+        $migrationDirs = $migrationDirs
+            ->map(static fn (string $dir): string => trim($dir))
+            ->filter(static fn (string $dir): bool => ! empty($dir))
+            ->map(static fn (string $dir): string => str_replace(base_path('/'), '', $dir));
+
+        foreach ($migrationDirs as $dir) {
+            // we could delete the directories, but that could cause damage if a bug happened,
+            // instead we'll just delete php files and only delete the directory afterwards if it is empty
+
+            $filesystem = new Filesystem;
+
+            $files = $filesystem->files($dir);
+
+            foreach ($files as $file) {
+                if ($file->getExtension() == 'php') {
+                    $filesystem->delete("$file");
+                }
+            }
+
+            if ($filesystem->isEmptyDirectory($dir)) {
+                $filesystem->deleteDirectory($dir);
+            }
+        }
+    }
+
+    /**
+     * Register the listeners for the subscriber.
+     */
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen(MigrationsPruned::class, [$this, 'handle']);
+    }
+}


### PR DESCRIPTION
Laravel has a command `php artisan schema:dump --prune` which creates SQL database dump to use instead of database migrations and then deletes the migrations if the --prune options is used.

However, I found out that Laravel only deletes the project root database/migrations directory and not individual migration files that can be present in the different domains created with this package.

So I created that an event listener that does this. I tried to be careful with the code not to accidentally delete someone's project. Theoretically some additional measures like checking the contents of the files which are to be deleted, could be added. Or maybe this action could be enabled through the config only if the developer needs it. Let me know if you want more to be done in this direction.

Notes:
- I had to add `Event::subscribe(MigrationsPrunedSubscriber::class);` to the service provider, however there is not a similar registration for the other event subscriber in the package. Either the existing one is not working or I am doing something wrong.