### PR TITLE
Add generic Factory on HasDomainFactory trait

### DIFF
--- a/src/Factories/HasDomainFactory.php
+++ b/src/Factories/HasDomainFactory.php
@@ -4,10 +4,16 @@ namespace Lunarstorm\LaravelDDD\Factories;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @template TFactory of \Illuminate\Database\Eloquent\Factories\Factory
+ */
 trait HasDomainFactory
 {
     use HasFactory;
 
+    /**
+     * @return ?TFactory
+     */
     protected static function newFactory()
     {
         return DomainFactory::factoryForModel(get_called_class());


### PR DESCRIPTION
Helps PHP analyzers like PHPStan to find correct generic, eg.

```php
use Illuminate\Database\Eloquent\Model;
use Lunarstorm\LaravelDDD\Factories\HasDomainFactory as HasFactory;

class MyModel extends Model
{
    /** @use HasFactory<MyModelFactory> */
    use HasFactory;

   ....
}
```