### PR TITLE
V3

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/lunarstorm/laravel-ddd/discussions/new?category=q-a
+    url: https://github.com/jaspertey/laravel-ddd/discussions/new?category=q-a
     about: Ask the community for help
   - name: Request a feature
-    url: https://github.com/lunarstorm/laravel-ddd/discussions/new?category=ideas
+    url: https://github.com/jaspertey/laravel-ddd/discussions/new?category=ideas
     about: Share ideas for new features
   - name: Report a security issue
-    url: https://github.com/lunarstorm/laravel-ddd/security/policy
+    url: https://github.com/jaspertey/laravel-ddd/security/policy
     about: Learn how to notify us for sensitive bugs
   - name: Report a bug
-    url: https://github.com/lunarstorm/laravel-ddd/issues/new
+    url: https://github.com/jaspertey/laravel-ddd/issues/new
     about: Report a reproducible bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-ddd` will be documented in this file.
 
+## [3.0.0] - unreleased
+
+### Changed
+- Package renamed from `lunarstorm/laravel-ddd` to `tey/laravel-ddd`.
+- PHP namespace changed from `Lunarstorm\LaravelDDD` to `Tey\LaravelDDD`.
+- Repository moved to [jaspertey/laravel-ddd](https://github.com/jaspertey/laravel-ddd).
+
 ## [2.1.1] - 2026-03-24
 ### Added
 - Domain event listener and subscriber auto-discovery via `ddd.autoload.listeners` (opt-in, disabled by default).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Domain Driven Design Toolkit for Laravel
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/lunarstorm/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/lunarstorm/laravel-ddd)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/lunarstorm/laravel-ddd/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/lunarstorm/laravel-ddd/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/lunarstorm/laravel-ddd/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/lunarstorm/laravel-ddd/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
-[![Total Downloads](https://img.shields.io/packagist/dt/lunarstorm/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/lunarstorm/laravel-ddd)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/tey/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/tey/laravel-ddd)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/tey/laravel-ddd/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/tey/laravel-ddd/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/tey/laravel-ddd/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/tey/laravel-ddd/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
+[![Total Downloads](https://img.shields.io/packagist/dt/tey/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/tey/laravel-ddd)
 
 Laravel-DDD is a toolkit to support domain driven design (DDD) in Laravel applications. One of the pain points when adopting DDD is the inability to use Laravel's native `make` commands to generate objects outside the `App\*` namespace. This package aims to fill the gaps by providing equivalent commands such as `ddd:model`, `ddd:dto`, `ddd:view-model` and many more.
 
@@ -11,7 +11,7 @@ Laravel-DDD is a toolkit to support domain driven design (DDD) in Laravel applic
 You can install the package via composer:
 
 ```bash
-composer require lunarstorm/laravel-ddd
+composer require tey/laravel-ddd
 ```
 
 You may initialize the package using the `ddd:install` artisan command. This will publish the [config file](#config-file), register the domain path in your project's composer.json psr-4 autoload configuration on your behalf, and allow you to publish generator stubs for customization if needed.
@@ -43,7 +43,7 @@ In production, ensure you run `php artisan ddd:optimize` during the deployment p
 ### Version Compatibility
  Laravel        | LaravelDDD |                                                                                      |
 :---------------|:-----------|:-------------------------------------------------------------------------------------|
- 9.x - 10.24.x  | 0.x        | **[0.x README](https://github.com/lunarstorm/laravel-ddd/blob/v0.10.0/README.md)**   |
+ 9.x - 10.24.x  | 0.x        | **[0.x README](https://github.com/tey/laravel-ddd/blob/v0.10.0/README.md)**   |
  10.25.x        | 1.x        |  
  11.x           | 1.x        |
  11.44.x        | 2.x        |
@@ -274,9 +274,9 @@ php artisan ddd:exception Invoicing:/Models/Exceptions/InvoiceNotFoundException
 ### Custom Object Resolution
 If you require advanced customization of generated object naming conventions, you may register a custom resolver using `DDD::resolveObjectSchemaUsing()` in your AppServiceProvider's boot method: 
 ```php
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\ValueObjects\CommandContext;
-use Lunarstorm\LaravelDDD\ValueObjects\ObjectSchema;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\ValueObjects\CommandContext;
+use Tey\LaravelDDD\ValueObjects\ObjectSchema;
 
 DDD::resolveObjectSchemaUsing(function (string $domainName, string $nameInput, string $type, CommandContext $command): ?ObjectSchema {
     if ($type === 'controller' && $command->option('api')) {
@@ -384,7 +384,7 @@ When `ddd.autoload.commands` is enabled, any class within the domain layer exten
 When `ddd.autoload.policies` is enabled, the package will register a custom policy discovery callback to resolve policy names for domain models, and fallback to Laravel's default for all other cases. If your application implements its own policy discovery using `Gate::guessPolicyNamesUsing()`, you should set `ddd.autoload.policies` to `false` to ensure it is not overridden.
 
 ### Factories
-When `ddd.autoload.factories` is enabled, the package will register a custom factory discovery callback to resolve factory names for domain models, and fallback to Laravel's default for all other cases. Note that this does not affect domain models using the `Lunarstorm\LaravelDDD\Factories\HasDomainFactory` trait. Where this is useful is with regular models in the domain layer that use the standard `Illuminate\Database\Eloquent\Factories\HasFactory` trait.
+When `ddd.autoload.factories` is enabled, the package will register a custom factory discovery callback to resolve factory names for domain models, and fallback to Laravel's default for all other cases. Note that this does not affect domain models using the `Tey\LaravelDDD\Factories\HasDomainFactory` trait. Where this is useful is with regular models in the domain layer that use the standard `Illuminate\Database\Eloquent\Factories\HasFactory` trait.
 
 If your application implements its own factory discovery using `Factory::guessFactoryNamesUsing()`, you should set `ddd.autoload.factories` to `false` to ensure it is not overridden.
 
@@ -415,7 +415,7 @@ Note that ignoring folders only applies to class-based autoloading: Service Prov
 
 Paths specified here are relative to the root of each domain. e.g., `src/Domain/Invoicing/{path-to-ignore}`. If more advanced filtering is needed, a callback can be registered using `DDD::filterAutoloadPathsUsing(callback $filter)` in your AppServiceProvider's boot method:
 ```php
-use Lunarstorm\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Facades\DDD;
 use Symfony\Component\Finder\SplFileInfo;
 
 DDD::filterAutoloadPathsUsing(function (SplFileInfo $file) {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Domain Driven Design Toolkit for Laravel
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/tey/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/tey/laravel-ddd)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/tey/laravel-ddd/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/tey/laravel-ddd/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/tey/laravel-ddd/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/tey/laravel-ddd/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/jaspertey/laravel-ddd/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/jaspertey/laravel-ddd/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/jaspertey/laravel-ddd/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/jaspertey/laravel-ddd/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/tey/laravel-ddd.svg?style=flat-square)](https://packagist.org/packages/tey/laravel-ddd)
 
 Laravel-DDD is a toolkit to support domain driven design (DDD) in Laravel applications. One of the pain points when adopting DDD is the inability to use Laravel's native `make` commands to generate objects outside the `App\*` namespace. This package aims to fill the gaps by providing equivalent commands such as `ddd:model`, `ddd:dto`, `ddd:view-model` and many more.
@@ -43,7 +43,7 @@ In production, ensure you run `php artisan ddd:optimize` during the deployment p
 ### Version Compatibility
  Laravel        | LaravelDDD |                                                                                      |
 :---------------|:-----------|:-------------------------------------------------------------------------------------|
- 9.x - 10.24.x  | 0.x        | **[0.x README](https://github.com/tey/laravel-ddd/blob/v0.10.0/README.md)**   |
+ 9.x - 10.24.x  | 0.x        | **[0.x README](https://github.com/jaspertey/laravel-ddd/blob/v0.10.0/README.md)**   |
  10.25.x        | 1.x        |  
  11.x           | 1.x        |
  11.44.x        | 2.x        |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,32 @@
 # Upgrading
 
+## From 2.x to 3.0.0
+
+### Package Rename
+The package has moved from `lunarstorm/laravel-ddd` to `tey/laravel-ddd`.
+
+```bash
+composer remove lunarstorm/laravel-ddd
+composer require tey/laravel-ddd:^3.0
+```
+
+### PHP Namespace Change
+The root PHP namespace has changed from `Lunarstorm\LaravelDDD` to `Tey\LaravelDDD`.
+
+Find and replace throughout your application:
+```
+Lunarstorm\LaravelDDD  →  Tey\LaravelDDD
+```
+
+### Re-publish Config (if previously published)
+```bash
+php artisan vendor:publish --tag=ddd-config --force
+```
+
+Review any local customizations after re-publishing.
+
+---
+
 ## From 1.2.x to 2.0.x
 - Minimum required Laravel version is 11.44.
 - Minimum PHP version is now 8.2.

--- a/composer.json
+++ b/composer.json
@@ -1,19 +1,19 @@
 {
-    "name": "lunarstorm/laravel-ddd",
+    "name": "tey/laravel-ddd",
     "description": "A Laravel toolkit for Domain Driven Design patterns",
     "keywords": [
-        "lunarstorm",
+        "tey",
         "laravel",
         "laravel-ddd",
         "ddd",
         "domain driven design"
     ],
-    "homepage": "https://github.com/lunarstorm/laravel-ddd",
+    "homepage": "https://github.com/jaspertey/laravel-ddd",
     "license": "MIT",
     "authors": [
         {
             "name": "Jasper Tey",
-            "email": "jasper@lunarstorm.ca",
+            "email": "jasper@jtey.com",
             "role": "Developer"
         }
     ],
@@ -44,13 +44,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Lunarstorm\\LaravelDDD\\": "src",
-            "Lunarstorm\\LaravelDDD\\Database\\Factories\\": "database/factories"
+            "Tey\\LaravelDDD\\": "src",
+            "Tey\\LaravelDDD\\Database\\Factories\\": "database/factories"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Lunarstorm\\LaravelDDD\\Tests\\": "tests",
+            "Tey\\LaravelDDD\\Tests\\": "tests",
             "App\\": "vendor/orchestra/testbench-core/laravel/app",
             "Database\\Factories\\": "vendor/orchestra/testbench-core/laravel/database/factories",
             "Database\\Seeders\\": "vendor/orchestra/testbench-core/laravel/database/seeders",
@@ -78,10 +78,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Lunarstorm\\LaravelDDD\\LaravelDDDServiceProvider"
+                "Tey\\LaravelDDD\\LaravelDDDServiceProvider"
             ],
             "aliases": {
-                "DDD": "Lunarstorm\\LaravelDDD\\Facades\\DDD"
+                "DDD": "Tey\\LaravelDDD\\Facades\\DDD"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "laravel/prompts": "^0.3.1",
         "lorisleiva/lody": "^0.6|^0.7",
         "spatie/laravel-package-tools": "^1.19.0",
+        "symfony/finder": "^7.0",
         "symfony/var-exporter": "^7.1"
     },
     "require-dev": {

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Database\Factories;
+namespace Tey\LaravelDDD\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 

--- a/routes/testing.php
+++ b/routes/testing.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Lunarstorm\LaravelDDD\Facades\Autoload;
+use Tey\LaravelDDD\Facades\Autoload;
 
 Route::prefix('laravel-ddd')
     ->middleware(['web'])

--- a/src/Commands/Concerns/ForwardsToDomainCommands.php
+++ b/src/Commands/Concerns/ForwardsToDomainCommands.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
 use Illuminate\Support\Str;
 

--- a/src/Commands/Concerns/HandleHooks.php
+++ b/src/Commands/Concerns/HandleHooks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
 trait HandleHooks
 {

--- a/src/Commands/Concerns/HasDomainStubs.php
+++ b/src/Commands/Concerns/HasDomainStubs.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Facades\DDD;
 
 trait HasDomainStubs
 {

--- a/src/Commands/Concerns/HasGeneratorBlueprint.php
+++ b/src/Commands/Concerns/HasGeneratorBlueprint.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
-use Lunarstorm\LaravelDDD\Support\GeneratorBlueprint;
+use Tey\LaravelDDD\Support\GeneratorBlueprint;
 
 trait HasGeneratorBlueprint
 {

--- a/src/Commands/Concerns/InteractsWithStubs.php
+++ b/src/Commands/Concerns/InteractsWithStubs.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
 trait InteractsWithStubs
 {

--- a/src/Commands/Concerns/QualifiesDomainModels.php
+++ b/src/Commands/Concerns/QualifiesDomainModels.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
 trait QualifiesDomainModels
 {

--- a/src/Commands/Concerns/ResolvesDomainFromInput.php
+++ b/src/Commands/Concerns/ResolvesDomainFromInput.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Concerns;
+namespace Tey\LaravelDDD\Commands\Concerns;
 
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
-use Lunarstorm\LaravelDDD\Support\GeneratorBlueprint;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\GeneratorBlueprint;
 use Symfony\Component\Console\Input\InputOption;
 
 use function Laravel\Prompts\suggest;

--- a/src/Commands/Concerns/ResolvesDomainFromInput.php
+++ b/src/Commands/Concerns/ResolvesDomainFromInput.php
@@ -3,10 +3,10 @@
 namespace Tey\LaravelDDD\Commands\Concerns;
 
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 use Tey\LaravelDDD\Support\Domain;
 use Tey\LaravelDDD\Support\DomainResolver;
 use Tey\LaravelDDD\Support\GeneratorBlueprint;
-use Symfony\Component\Console\Input\InputOption;
 
 use function Laravel\Prompts\suggest;
 

--- a/src/Commands/ConfigCommand.php
+++ b/src/Commands/ConfigCommand.php
@@ -5,11 +5,11 @@ namespace Tey\LaravelDDD\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Tey\LaravelDDD\ComposerManager;
 use Tey\LaravelDDD\Facades\DDD;
 use Tey\LaravelDDD\Support\Layer;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\form;

--- a/src/Commands/ConfigCommand.php
+++ b/src/Commands/ConfigCommand.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\ComposerManager;
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\Support\Layer;
+use Tey\LaravelDDD\ComposerManager;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Support\Layer;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Commands/DomainActionMakeCommand.php
+++ b/src/Commands/DomainActionMakeCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 
 class DomainActionMakeCommand extends DomainGeneratorCommand
 {

--- a/src/Commands/DomainBaseModelMakeCommand.php
+++ b/src/Commands/DomainBaseModelMakeCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 use Symfony\Component\Console\Input\InputArgument;
 
 class DomainBaseModelMakeCommand extends DomainGeneratorCommand

--- a/src/Commands/DomainBaseModelMakeCommand.php
+++ b/src/Commands/DomainBaseModelMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace Tey\LaravelDDD\Commands;
 
-use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 use Symfony\Component\Console\Input\InputArgument;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 
 class DomainBaseModelMakeCommand extends DomainGeneratorCommand
 {

--- a/src/Commands/DomainBaseViewModelMakeCommand.php
+++ b/src/Commands/DomainBaseViewModelMakeCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 use Symfony\Component\Console\Input\InputArgument;
 
 class DomainBaseViewModelMakeCommand extends DomainGeneratorCommand

--- a/src/Commands/DomainBaseViewModelMakeCommand.php
+++ b/src/Commands/DomainBaseViewModelMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace Tey\LaravelDDD\Commands;
 
-use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 use Symfony\Component\Console\Input\InputArgument;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 
 class DomainBaseViewModelMakeCommand extends DomainGeneratorCommand
 {

--- a/src/Commands/DomainCastMakeCommand.php
+++ b/src/Commands/DomainCastMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\CastMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainCastMakeCommand extends CastMakeCommand
 {

--- a/src/Commands/DomainChannelMakeCommand.php
+++ b/src/Commands/DomainChannelMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ChannelMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainChannelMakeCommand extends ChannelMakeCommand
 {

--- a/src/Commands/DomainClassMakeCommand.php
+++ b/src/Commands/DomainClassMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ClassMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainClassMakeCommand extends ClassMakeCommand
 {

--- a/src/Commands/DomainConsoleMakeCommand.php
+++ b/src/Commands/DomainConsoleMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainConsoleMakeCommand extends ConsoleMakeCommand
 {

--- a/src/Commands/DomainControllerMakeCommand.php
+++ b/src/Commands/DomainControllerMakeCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Routing\Console\ControllerMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ForwardsToDomainCommands;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Commands\Concerns\ForwardsToDomainCommands;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Support\Path;
 
 class DomainControllerMakeCommand extends ControllerMakeCommand
 {

--- a/src/Commands/DomainDtoMakeCommand.php
+++ b/src/Commands/DomainDtoMakeCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 
 class DomainDtoMakeCommand extends DomainGeneratorCommand
 {

--- a/src/Commands/DomainEnumMakeCommand.php
+++ b/src/Commands/DomainEnumMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\EnumMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainEnumMakeCommand extends EnumMakeCommand
 {

--- a/src/Commands/DomainEventMakeCommand.php
+++ b/src/Commands/DomainEventMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\EventMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainEventMakeCommand extends EventMakeCommand
 {

--- a/src/Commands/DomainExceptionMakeCommand.php
+++ b/src/Commands/DomainExceptionMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ExceptionMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainExceptionMakeCommand extends ExceptionMakeCommand
 {

--- a/src/Commands/DomainFactoryMakeCommand.php
+++ b/src/Commands/DomainFactoryMakeCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\InteractsWithStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\InteractsWithStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainFactoryMakeCommand extends FactoryMakeCommand
 {

--- a/src/Commands/DomainGeneratorCommand.php
+++ b/src/Commands/DomainGeneratorCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Commands\Concerns\InteractsWithStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Commands\Concerns\InteractsWithStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 abstract class DomainGeneratorCommand extends GeneratorCommand
 {

--- a/src/Commands/DomainInterfaceMakeCommand.php
+++ b/src/Commands/DomainInterfaceMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\InterfaceMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainInterfaceMakeCommand extends InterfaceMakeCommand
 {

--- a/src/Commands/DomainJobMakeCommand.php
+++ b/src/Commands/DomainJobMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\JobMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainJobMakeCommand extends JobMakeCommand
 {

--- a/src/Commands/DomainListCommand.php
+++ b/src/Commands/DomainListCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\Path;
 
 use function Laravel\Prompts\table;
 

--- a/src/Commands/DomainListenerMakeCommand.php
+++ b/src/Commands/DomainListenerMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ListenerMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainListenerMakeCommand extends ListenerMakeCommand
 {

--- a/src/Commands/DomainMailMakeCommand.php
+++ b/src/Commands/DomainMailMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\MailMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainMailMakeCommand extends MailMakeCommand
 {

--- a/src/Commands/DomainMiddlewareMakeCommand.php
+++ b/src/Commands/DomainMiddlewareMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Routing\Console\MiddlewareMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainMiddlewareMakeCommand extends MiddlewareMakeCommand
 {

--- a/src/Commands/DomainModelMakeCommand.php
+++ b/src/Commands/DomainModelMakeCommand.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ForwardsToDomainCommands;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Commands\Concerns\ForwardsToDomainCommands;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 class DomainModelMakeCommand extends ModelMakeCommand
 {
@@ -62,7 +62,7 @@ class DomainModelMakeCommand extends ModelMakeCommand
             EOT;
 
             $replacements['{{ factory }}'] = $factoryCode;
-            $replacements['{{ factoryImport }}'] = 'use Lunarstorm\LaravelDDD\Factories\HasDomainFactory as HasFactory;';
+            $replacements['{{ factoryImport }}'] = 'use Tey\LaravelDDD\Factories\HasDomainFactory as HasFactory;';
         }
 
         return $replacements;

--- a/src/Commands/DomainNotificationMakeCommand.php
+++ b/src/Commands/DomainNotificationMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\NotificationMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainNotificationMakeCommand extends NotificationMakeCommand
 {

--- a/src/Commands/DomainObserverMakeCommand.php
+++ b/src/Commands/DomainObserverMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ObserverMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainObserverMakeCommand extends ObserverMakeCommand
 {

--- a/src/Commands/DomainPolicyMakeCommand.php
+++ b/src/Commands/DomainPolicyMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\PolicyMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainPolicyMakeCommand extends PolicyMakeCommand
 {

--- a/src/Commands/DomainProviderMakeCommand.php
+++ b/src/Commands/DomainProviderMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ProviderMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainProviderMakeCommand extends ProviderMakeCommand
 {

--- a/src/Commands/DomainRequestMakeCommand.php
+++ b/src/Commands/DomainRequestMakeCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\RequestMakeCommand;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 class DomainRequestMakeCommand extends RequestMakeCommand
 {

--- a/src/Commands/DomainResourceMakeCommand.php
+++ b/src/Commands/DomainResourceMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ResourceMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainResourceMakeCommand extends ResourceMakeCommand
 {

--- a/src/Commands/DomainRuleMakeCommand.php
+++ b/src/Commands/DomainRuleMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\RuleMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainRuleMakeCommand extends RuleMakeCommand
 {

--- a/src/Commands/DomainScopeMakeCommand.php
+++ b/src/Commands/DomainScopeMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\ScopeMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainScopeMakeCommand extends ScopeMakeCommand
 {

--- a/src/Commands/DomainSeederMakeCommand.php
+++ b/src/Commands/DomainSeederMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainSeederMakeCommand extends SeederMakeCommand
 {

--- a/src/Commands/DomainTraitMakeCommand.php
+++ b/src/Commands/DomainTraitMakeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Foundation\Console\TraitMakeCommand;
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
 
 class DomainTraitMakeCommand extends TraitMakeCommand
 {

--- a/src/Commands/DomainValueObjectMakeCommand.php
+++ b/src/Commands/DomainValueObjectMakeCommand.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
 
 class DomainValueObjectMakeCommand extends DomainGeneratorCommand
 {

--- a/src/Commands/DomainViewModelMakeCommand.php
+++ b/src/Commands/DomainViewModelMakeCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\HasDomainStubs;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Commands\Concerns\HasDomainStubs;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 class DomainViewModelMakeCommand extends DomainGeneratorCommand
 {

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
 

--- a/src/Commands/Migration/BaseMigrateMakeCommand.php
+++ b/src/Commands/Migration/BaseMigrateMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Migration;
+namespace Tey\LaravelDDD\Commands\Migration;
 
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Commands/Migration/DomainMigrateMakeCommand.php
+++ b/src/Commands/Migration/DomainMigrateMakeCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands\Migration;
+namespace Tey\LaravelDDD\Commands\Migration;
 
-use Lunarstorm\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Commands\Concerns\ResolvesDomainFromInput;
+use Tey\LaravelDDD\Support\Path;
 
 class DomainMigrateMakeCommand extends BaseMigrateMakeCommand
 {

--- a/src/Commands/OptimizeClearCommand.php
+++ b/src/Commands/OptimizeClearCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Support\DomainCache;
 
 class OptimizeClearCommand extends Command
 {

--- a/src/Commands/OptimizeCommand.php
+++ b/src/Commands/OptimizeCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
-use Lunarstorm\LaravelDDD\Facades\Autoload;
-use Lunarstorm\LaravelDDD\Support\DomainMigration;
+use Tey\LaravelDDD\Facades\Autoload;
+use Tey\LaravelDDD\Support\DomainMigration;
 
 class OptimizeCommand extends Command
 {

--- a/src/Commands/PublishCommand.php
+++ b/src/Commands/PublishCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -6,10 +6,10 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\PublishingStubs;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Tey\LaravelDDD\Facades\DDD;
-use Tey\LaravelDDD\Support\Path;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Support\Path;
 
 use function Laravel\Prompts\multisearch;
 use function Laravel\Prompts\select;

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Events\PublishingStubs;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Support\Path;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Commands;
+namespace Tey\LaravelDDD\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -5,12 +5,19 @@ namespace Tey\LaravelDDD\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
+use Symfony\Component\Finder\Finder;
+
+use function Laravel\Prompts\confirm;
 
 class UpgradeCommand extends Command
 {
     protected $name = 'ddd:upgrade';
 
-    protected $description = 'Upgrade published config files for compatibility with 1.x.';
+    protected $description = 'Upgrade the package configuration and application code for compatibility with the latest version.';
+
+    const OLD_NAMESPACE = 'Lunarstorm\\LaravelDDD';
+
+    const NEW_NAMESPACE = 'Tey\\LaravelDDD';
 
     public function handle()
     {
@@ -20,6 +27,98 @@ class UpgradeCommand extends Command
             return self::SUCCESS;
         }
 
+        $this->handleV3Upgrade();
+
+        $this->handleConfigUpgrade();
+
+        return self::SUCCESS;
+    }
+
+    protected function handleV3Upgrade(): void
+    {
+        $this->components->info('Checking for v3 migration requirements...');
+
+        $this->migrateConfigNamespaces();
+        $this->migrateAppNamespaces();
+    }
+
+    protected function migrateConfigNamespaces(): void
+    {
+        $configPath = config_path('ddd.php');
+        $contents = file_get_contents($configPath);
+
+        if (! str_contains($contents, static::OLD_NAMESPACE)) {
+            return;
+        }
+
+        $updated = str_replace(static::OLD_NAMESPACE, static::NEW_NAMESPACE, $contents);
+        file_put_contents($configPath, $updated);
+
+        $this->components->twoColumnDetail('Updated namespace references in config/ddd.php', '<fg=green;options=bold>DONE</>');
+    }
+
+    protected function migrateAppNamespaces(): void
+    {
+        $searchPaths = array_filter([
+            app_path(),
+            base_path('src'),
+        ], fn ($path) => is_dir($path));
+
+        if (empty($searchPaths)) {
+            return;
+        }
+
+        $finder = Finder::create()
+            ->in($searchPaths)
+            ->name('*.php')
+            ->contains(static::OLD_NAMESPACE)
+            ->files();
+
+        $files = iterator_to_array($finder);
+
+        if (empty($files)) {
+            $this->components->twoColumnDetail('No application files require namespace updates', '<fg=green;options=bold>NONE</>');
+
+            return;
+        }
+
+        $this->components->warn(sprintf(
+            'Found %d file(s) referencing the old namespace <fg=yellow>%s</>:',
+            count($files),
+            static::OLD_NAMESPACE,
+        ));
+
+        foreach ($files as $file) {
+            $this->line('  <fg=gray>'.$file->getRelativePathname().'</>');
+        }
+
+        $this->newLine();
+
+        if (! confirm(sprintf(
+            'Replace all occurrences of [%s] with [%s]?',
+            static::OLD_NAMESPACE,
+            static::NEW_NAMESPACE,
+        ), default: true)) {
+            $this->components->warn('Skipped. You will need to update these files manually.');
+
+            return;
+        }
+
+        foreach ($files as $file) {
+            $updated = str_replace(
+                static::OLD_NAMESPACE,
+                static::NEW_NAMESPACE,
+                file_get_contents($file->getRealPath()),
+            );
+
+            file_put_contents($file->getRealPath(), $updated);
+
+            $this->components->twoColumnDetail($file->getRelativePathname(), '<fg=green;options=bold>UPDATED</>');
+        }
+    }
+
+    protected function handleConfigUpgrade(): void
+    {
         $legacyMapping = [
             'domain_path' => 'paths.domain',
             'domain_namespace' => 'domain_namespace',
@@ -95,7 +194,5 @@ class UpgradeCommand extends Command
         file_put_contents(config_path('ddd.php'), $newConfigContent);
 
         $this->components->info('Configuration upgraded successfully.');
-
-        return self::SUCCESS;
     }
 }

--- a/src/ComposerManager.php
+++ b/src/ComposerManager.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD;
+namespace Tey\LaravelDDD;
 
 use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Path;
 
 class ComposerManager
 {

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -4,8 +4,8 @@ namespace Tey\LaravelDDD;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Process;
-use Tey\LaravelDDD\Facades\DDD;
 use Symfony\Component\VarExporter\VarExporter;
+use Tey\LaravelDDD\Facades\DDD;
 
 class ConfigManager
 {

--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD;
+namespace Tey\LaravelDDD;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Process;
-use Lunarstorm\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Facades\DDD;
 use Symfony\Component\VarExporter\VarExporter;
 
 class ConfigManager

--- a/src/DomainManager.php
+++ b/src/DomainManager.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD;
+namespace Tey\LaravelDDD;
 
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\GeneratorBlueprint;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\GeneratorBlueprint;
+use Tey\LaravelDDD\Support\Path;
 
 class DomainManager
 {

--- a/src/Enums/LayerType.php
+++ b/src/Enums/LayerType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Enums;
+namespace Tey\LaravelDDD\Enums;
 
 enum LayerType: string
 {

--- a/src/Events/DomainMigrationsPruned.php
+++ b/src/Events/DomainMigrationsPruned.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Events;
+namespace Tey\LaravelDDD\Events;
 
 use Illuminate\Database\Events\MigrationsPruned;
 

--- a/src/Facades/Autoload.php
+++ b/src/Facades/Autoload.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Facades;
+namespace Tey\LaravelDDD\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\AutoloadManager;
 
 /**
  * @see AutoloadManager

--- a/src/Facades/DDD.php
+++ b/src/Facades/DDD.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Facades;
+namespace Tey\LaravelDDD\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Lunarstorm\LaravelDDD\DomainManager;
+use Tey\LaravelDDD\DomainManager;
 
 /**
  * @see DomainManager
@@ -12,10 +12,10 @@ use Lunarstorm\LaravelDDD\DomainManager;
  * @method static ?callable getAutoloadFilter()
  * @method static void resolveObjectSchemaUsing(callable $resolver)
  * @method static string packagePath(string $path = '')
- * @method static \Lunarstorm\LaravelDDD\Support\AutoloadManager autoloader()
- * @method static \Lunarstorm\LaravelDDD\ConfigManager config()
- * @method static \Lunarstorm\LaravelDDD\StubManager stubs()
- * @method static \Lunarstorm\LaravelDDD\ComposerManager composer()
+ * @method static \Tey\LaravelDDD\Support\AutoloadManager autoloader()
+ * @method static \Tey\LaravelDDD\ConfigManager config()
+ * @method static \Tey\LaravelDDD\StubManager stubs()
+ * @method static \Tey\LaravelDDD\ComposerManager composer()
  */
 class DDD extends Facade
 {

--- a/src/Factories/DomainFactory.php
+++ b/src/Factories/DomainFactory.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Factories;
+namespace Tey\LaravelDDD\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
-use Lunarstorm\LaravelDDD\ValueObjects\DomainObject;
+use Tey\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\ValueObjects\DomainObject;
 
 abstract class DomainFactory extends Factory
 {

--- a/src/Factories/HasDomainFactory.php
+++ b/src/Factories/HasDomainFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Factories;
+namespace Tey\LaravelDDD\Factories;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 

--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD;
+namespace Tey\LaravelDDD;
 
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Facades\Event;
-use Lunarstorm\LaravelDDD\Facades\Autoload;
-use Lunarstorm\LaravelDDD\Listeners\MigrationsPrunedSubscriber;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\DomainMigration;
+use Tey\LaravelDDD\Facades\Autoload;
+use Tey\LaravelDDD\Listeners\MigrationsPrunedSubscriber;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\DomainMigration;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 

--- a/src/LaravelDDDServiceProvider.php
+++ b/src/LaravelDDDServiceProvider.php
@@ -4,12 +4,12 @@ namespace Tey\LaravelDDD;
 
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Facades\Event;
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tey\LaravelDDD\Facades\Autoload;
 use Tey\LaravelDDD\Listeners\MigrationsPrunedSubscriber;
 use Tey\LaravelDDD\Support\AutoloadManager;
 use Tey\LaravelDDD\Support\DomainMigration;
-use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class LaravelDDDServiceProvider extends PackageServiceProvider
 {

--- a/src/Listeners/CacheClearSubscriber.php
+++ b/src/Listeners/CacheClearSubscriber.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Listeners;
+namespace Tey\LaravelDDD\Listeners;
 
 use Illuminate\Events\Dispatcher;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Support\DomainCache;
 
 class CacheClearSubscriber
 {

--- a/src/Listeners/MigrationsPrunedSubscriber.php
+++ b/src/Listeners/MigrationsPrunedSubscriber.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Listeners;
+namespace Tey\LaravelDDD\Listeners;
 
 use Illuminate\Database\Events\MigrationsPruned;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
-use Lunarstorm\LaravelDDD\Events\DomainMigrationsPruned;
-use Lunarstorm\LaravelDDD\Support\DomainMigration;
+use Tey\LaravelDDD\Events\DomainMigrationsPruned;
+use Tey\LaravelDDD\Support\DomainMigration;
 
 class MigrationsPrunedSubscriber
 {

--- a/src/Models/DomainModel.php
+++ b/src/Models/DomainModel.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Models;
+namespace Tey\LaravelDDD\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Lunarstorm\LaravelDDD\Factories\HasDomainFactory;
+use Tey\LaravelDDD\Factories\HasDomainFactory;
 
 abstract class DomainModel extends Model
 {

--- a/src/StubManager.php
+++ b/src/StubManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD;
+namespace Tey\LaravelDDD;
 
 use Illuminate\Foundation\Console\StubPublishCommand;
 use ReflectionClass;

--- a/src/Support/AutoloadManager.php
+++ b/src/Support/AutoloadManager.php
@@ -17,13 +17,13 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Lorisleiva\Lody\Lody;
-use Tey\LaravelDDD\Facades\DDD;
-use Tey\LaravelDDD\Factories\DomainFactory;
-use Tey\LaravelDDD\ValueObjects\DomainObject;
 use Mockery;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Factories\DomainFactory;
+use Tey\LaravelDDD\ValueObjects\DomainObject;
 use Throwable;
 
 class AutoloadManager

--- a/src/Support/AutoloadManager.php
+++ b/src/Support/AutoloadManager.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 use Closure;
 use Illuminate\Console\Application as ConsoleApplication;
@@ -17,9 +17,9 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Lorisleiva\Lody\Lody;
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\Factories\DomainFactory;
-use Lunarstorm\LaravelDDD\ValueObjects\DomainObject;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Factories\DomainFactory;
+use Tey\LaravelDDD\ValueObjects\DomainObject;
 use Mockery;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;

--- a/src/Support/Domain.php
+++ b/src/Support/Domain.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
-use Lunarstorm\LaravelDDD\ValueObjects\DomainObject;
+use Tey\LaravelDDD\ValueObjects\DomainObject;
 
 class Domain
 {

--- a/src/Support/DomainCache.php
+++ b/src/Support/DomainCache.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 use Illuminate\Support\Facades\File;
 

--- a/src/Support/DomainMigration.php
+++ b/src/Support/DomainMigration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 use Illuminate\Support\Str;
 use Lorisleiva\Lody\Lody;

--- a/src/Support/DomainResolver.php
+++ b/src/Support/DomainResolver.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Enums\LayerType;
+use Tey\LaravelDDD\Enums\LayerType;
 
 class DomainResolver
 {

--- a/src/Support/GeneratorBlueprint.php
+++ b/src/Support/GeneratorBlueprint.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
-use Lunarstorm\LaravelDDD\ValueObjects\CommandContext;
-use Lunarstorm\LaravelDDD\ValueObjects\ObjectSchema;
+use Tey\LaravelDDD\ValueObjects\CommandContext;
+use Tey\LaravelDDD\ValueObjects\ObjectSchema;
 
 class GeneratorBlueprint
 {

--- a/src/Support/Layer.php
+++ b/src/Support/Layer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Enums\LayerType;
+use Tey\LaravelDDD\Enums\LayerType;
 
 class Layer
 {

--- a/src/Support/Path.php
+++ b/src/Support/Path.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Support;
+namespace Tey\LaravelDDD\Support;
 
 class Path
 {

--- a/src/ValueObjects/CommandContext.php
+++ b/src/ValueObjects/CommandContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\ValueObjects;
+namespace Tey\LaravelDDD\ValueObjects;
 
 class CommandContext
 {

--- a/src/ValueObjects/DomainNamespaces.php
+++ b/src/ValueObjects/DomainNamespaces.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\ValueObjects;
+namespace Tey\LaravelDDD\ValueObjects;
 
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 class DomainNamespaces
 {

--- a/src/ValueObjects/DomainObject.php
+++ b/src/ValueObjects/DomainObject.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\ValueObjects;
+namespace Tey\LaravelDDD\ValueObjects;
 
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\Path;
 
 class DomainObject
 {

--- a/src/ValueObjects/DomainObjectNamespace.php
+++ b/src/ValueObjects/DomainObjectNamespace.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\ValueObjects;
+namespace Tey\LaravelDDD\ValueObjects;
 
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 class DomainObjectNamespace
 {

--- a/src/ValueObjects/ObjectSchema.php
+++ b/src/ValueObjects/ObjectSchema.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\ValueObjects;
+namespace Tey\LaravelDDD\ValueObjects;
 
 class ObjectSchema
 {

--- a/stubs/base-model.stub
+++ b/stubs/base-model.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use Lunarstorm\LaravelDDD\Factories\HasDomainFactory;
+use Tey\LaravelDDD\Factories\HasDomainFactory;
 use Illuminate\Database\Eloquent\Model;
 
 abstract class {{ class }} extends Model

--- a/tests/.skeleton/src/Application/Models/Login.php
+++ b/tests/.skeleton/src/Application/Models/Login.php
@@ -3,7 +3,7 @@
 namespace Application\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Lunarstorm\LaravelDDD\Factories\HasDomainFactory;
+use Tey\LaravelDDD\Factories\HasDomainFactory;
 
 class Login extends Model
 {

--- a/tests/.skeleton/src/Domain/Invoicing/Models/Invoice.php
+++ b/tests/.skeleton/src/Domain/Invoicing/Models/Invoice.php
@@ -2,7 +2,7 @@
 
 namespace Domain\Invoicing\Models;
 
-use Lunarstorm\LaravelDDD\Models\DomainModel;
+use Tey\LaravelDDD\Models\DomainModel;
 
 class Invoice extends DomainModel
 {

--- a/tests/.skeleton/src/Domain/Invoicing/Models/Payment.php
+++ b/tests/.skeleton/src/Domain/Invoicing/Models/Payment.php
@@ -2,7 +2,7 @@
 
 namespace Domain\Invoicing\Models;
 
-use Lunarstorm\LaravelDDD\Models\DomainModel;
+use Tey\LaravelDDD\Models\DomainModel;
 
 class Payment extends DomainModel
 {

--- a/tests/.skeleton/src/Infrastructure/Models/AppSession.php
+++ b/tests/.skeleton/src/Infrastructure/Models/AppSession.php
@@ -3,7 +3,7 @@
 namespace Infrastructure\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Lunarstorm\LaravelDDD\Factories\HasDomainFactory;
+use Tey\LaravelDDD\Factories\HasDomainFactory;
 
 class AppSession extends Model
 {

--- a/tests/Autoload/CommandTest.php
+++ b/tests/Autoload/CommandTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Autoload/FactoryTest.php
+++ b/tests/Autoload/FactoryTest.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Artisan;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Autoload/IgnoreTest.php
+++ b/tests/Autoload/IgnoreTest.php
@@ -3,10 +3,10 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use Symfony\Component\Finder\SplFileInfo;
 use Tey\LaravelDDD\Facades\DDD;
 use Tey\LaravelDDD\Support\DomainCache;
 use Tey\LaravelDDD\Tests\BootsTestApplication;
-use Symfony\Component\Finder\SplFileInfo;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Autoload/IgnoreTest.php
+++ b/tests/Autoload/IgnoreTest.php
@@ -3,9 +3,9 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 use Symfony\Component\Finder\SplFileInfo;
 
 uses(BootsTestApplication::class);

--- a/tests/Autoload/ListenerTest.php
+++ b/tests/Autoload/ListenerTest.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Autoload/PolicyTest.php
+++ b/tests/Autoload/PolicyTest.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Gate;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Autoload/ProviderTest.php
+++ b/tests/Autoload/ProviderTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 

--- a/tests/BootsTestApplication.php
+++ b/tests/BootsTestApplication.php
@@ -1,5 +1,5 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Tests;
+namespace Tey\LaravelDDD\Tests;
 
 trait BootsTestApplication {}

--- a/tests/Command/ConfigTest.php
+++ b/tests/Command/ConfigTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Commands\ConfigCommand;
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Commands\ConfigCommand;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Command/ListTest.php
+++ b/tests/Command/ListTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Arr;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Path;
 
 beforeEach(function () {
     $this->setupTestApplication();

--- a/tests/Command/OptimizeTest.php
+++ b/tests/Command/OptimizeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 uses(BootsTestApplication::class);
 

--- a/tests/Command/StubTest.php
+++ b/tests/Command/StubTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\File;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 use function PHPUnit\Framework\assertDirectoryDoesNotExist;
 use function PHPUnit\Framework\assertDirectoryExists;

--- a/tests/Command/UpgradeTest.php
+++ b/tests/Command/UpgradeTest.php
@@ -45,3 +45,86 @@ it('skips upgrade if config file was not published', function () {
 
     expect(file_exists($path))->toBeFalse();
 });
+
+describe('v3 namespace migration', function () {
+    beforeEach(function () {
+        // Publish a minimal config so the command doesn't bail early
+        $configFilePath = config_path('ddd.php');
+        if (! file_exists($configFilePath)) {
+            File::copy(__DIR__.'/../../config/ddd.php', $configFilePath);
+        }
+    });
+
+    afterEach(function () {
+        $path = config_path('ddd.php');
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    });
+
+    it('rewrites old namespace references in config/ddd.php', function () {
+        $configPath = config_path('ddd.php');
+        $original = file_get_contents($configPath);
+
+        // Inject an old namespace reference into the config
+        $modified = str_replace(
+            "'base_model' => null",
+            "'base_model' => 'Lunarstorm\\LaravelDDD\\Models\\DomainModel'",
+            $original,
+        );
+        file_put_contents($configPath, $modified);
+
+        expect(file_get_contents($configPath))->toContain('Lunarstorm\LaravelDDD');
+
+        $this->artisan('ddd:upgrade')->execute();
+
+        $config = require $configPath;
+
+        expect($config['base_model'])
+            ->not->toContain('Lunarstorm')
+            ->toContain('Tey\LaravelDDD');
+    });
+
+    it('reports no files when app has no old namespace references', function () {
+        $this->artisan('ddd:upgrade')
+            ->expectsOutputToContain('No application files require namespace updates')
+            ->execute();
+    });
+
+    it('replaces old namespace in app php files when confirmed', function () {
+        $tmpFile = app_path('SomeService.php');
+        File::ensureDirectoryExists(app_path());
+        file_put_contents($tmpFile, "<?php\nuse Lunarstorm\\LaravelDDD\\Facades\\DDD;\n");
+
+        $this->artisan('ddd:upgrade')
+            ->expectsConfirmation(
+                'Replace all occurrences of [Lunarstorm\LaravelDDD] with [Tey\LaravelDDD]?',
+                'yes',
+            )
+            ->execute();
+
+        expect(file_get_contents($tmpFile))
+            ->not->toContain('Lunarstorm\\LaravelDDD')
+            ->toContain('Tey\\LaravelDDD');
+
+        unlink($tmpFile);
+    });
+
+    it('skips replacing app files when not confirmed', function () {
+        $tmpFile = app_path('SomeService.php');
+        File::ensureDirectoryExists(app_path());
+        file_put_contents($tmpFile, "<?php\nuse Lunarstorm\\LaravelDDD\\Facades\\DDD;\n");
+
+        $this->artisan('ddd:upgrade')
+            ->expectsConfirmation(
+                'Replace all occurrences of [Lunarstorm\LaravelDDD] with [Tey\LaravelDDD]?',
+                'no',
+            )
+            ->expectsOutputToContain('You will need to update these files manually.')
+            ->execute();
+
+        expect(file_get_contents($tmpFile))->toContain('Lunarstorm\\LaravelDDD');
+
+        unlink($tmpFile);
+    });
+});

--- a/tests/Config/ManagerTest.php
+++ b/tests/Config/ManagerTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
-use Lunarstorm\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\Facades\DDD;
 
 beforeEach(function () {
     $this->cleanSlate();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 it('can customize the domain path via ddd.domain_path', function () {
     $path = fake()->word();

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Path;
 
 use function PHPUnit\Framework\assertMatchesRegularExpression;
 

--- a/tests/Factory/DomainFactoryTest.php
+++ b/tests/Factory/DomainFactoryTest.php
@@ -3,8 +3,8 @@
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Artisan;
-use Lunarstorm\LaravelDDD\Factories\DomainFactory;
-use Lunarstorm\LaravelDDD\Tests\BootsTestApplication;
+use Tey\LaravelDDD\Factories\DomainFactory;
+use Tey\LaravelDDD\Tests\BootsTestApplication;
 
 uses(BootsTestApplication::class);
 
@@ -36,7 +36,7 @@ it('can instantiate a domain model factory', function ($domainParameter, $modelN
     });
 
     $this->refreshApplicationWithConfig([
-        'ddd.base_model' => 'Lunarstorm\LaravelDDD\Models\DomainModel',
+        'ddd.base_model' => 'Tey\LaravelDDD\Models\DomainModel',
         'ddd.autoload.factories' => true,
     ]);
 

--- a/tests/Fixtures/Enums/Feature.php
+++ b/tests/Fixtures/Enums/Feature.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Tests\Fixtures\Enums;
+namespace Tey\LaravelDDD\Tests\Fixtures\Enums;
 
 enum Feature: string
 {

--- a/tests/Generator/AbsoluteNameTest.php
+++ b/tests/Generator/AbsoluteNameTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Path;
 
 it('can override configured object namespace by using absolute dot-path', function ($type, $nameInput, $expectedNamespace, $expectedPath) {
     if (in_array($type, ['class', 'enum', 'interface', 'trait'])) {

--- a/tests/Generator/ActionMakeTest.php
+++ b/tests/Generator/ActionMakeTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate action objects', function ($domainPath, $domainRoot) {
     Config::set('ddd.domain_path', $domainPath);

--- a/tests/Generator/BaseModelMakeTest.php
+++ b/tests/Generator/BaseModelMakeTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate domain base model', function ($domainPath, $domainRoot) {
     Config::set('ddd.domain_path', $domainPath);

--- a/tests/Generator/ControllerMakeTest.php
+++ b/tests/Generator/ControllerMakeTest.php
@@ -3,8 +3,8 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
-use Lunarstorm\LaravelDDD\Support\Path;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 beforeEach(function () {
     $this->cleanSlate();

--- a/tests/Generator/DtoMakeTest.php
+++ b/tests/Generator/DtoMakeTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate data transfer objects', function ($domainPath, $domainRoot) {
     Config::set('ddd.domain_path', $domainPath);

--- a/tests/Generator/ExtendedMakeTest.php
+++ b/tests/Generator/ExtendedMakeTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Support\Domain;
 
 it('can generate other objects', function ($type, $objectName, $domainPath, $domainRoot) {
     if (in_array($type, ['class', 'enum', 'interface', 'trait'])) {

--- a/tests/Generator/FactoryMakeTest.php
+++ b/tests/Generator/FactoryMakeTest.php
@@ -3,9 +3,9 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Support\Path;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate domain factories', function ($domainPath, $domainRoot, $domain, $subdomain) {
     Config::set('ddd.domain_path', $domainPath);

--- a/tests/Generator/MigrationMakeTest.php
+++ b/tests/Generator/MigrationMakeTest.php
@@ -3,10 +3,10 @@
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
-use Lunarstorm\LaravelDDD\Support\DomainMigration;
-use Lunarstorm\LaravelDDD\Support\Path;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Support\DomainMigration;
+use Tey\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 beforeEach(function () {
     config([

--- a/tests/Generator/Model/MakeTest.php
+++ b/tests/Generator/Model/MakeTest.php
@@ -3,8 +3,8 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 beforeEach(function () {
     $this->cleanSlate();
@@ -184,7 +184,7 @@ it('skips base model creation if configured base model already exists', function
     expect(Artisan::output())->not->toContain("Configured base model {$baseModel} doesn't exist, generating...");
 })->with([
     ['Illuminate\Database\Eloquent\Model'],
-    ['Lunarstorm\LaravelDDD\Models\DomainModel'],
+    ['Tey\LaravelDDD\Models\DomainModel'],
 ]);
 
 it('extends custom base models when applicable', function ($baseModelClass, $baseModelName) {
@@ -213,7 +213,7 @@ it('extends custom base models when applicable', function ($baseModelClass, $bas
         ->toContain("extends {$baseModelName}");
 })->with([
     ['Domain\Shared\Models\BaseModel', 'BaseModel'],
-    ['Lunarstorm\LaravelDDD\Models\DomainModel', 'DomainModel'],
+    ['Tey\LaravelDDD\Models\DomainModel', 'DomainModel'],
     ['Illuminate\Database\Eloquent\NonExistentModel', 'NonExistentModel'],
     ['OtherVendor\OtherPackage\Models\NonExistentModel', 'NonExistentModel'],
 ]);

--- a/tests/Generator/Model/MakeWithControllerTest.php
+++ b/tests/Generator/Model/MakeWithControllerTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Artisan;
-use Lunarstorm\LaravelDDD\Models\DomainModel;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Models\DomainModel;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 beforeEach(function () {
     config([

--- a/tests/Generator/Model/MakeWithOptionsTest.php
+++ b/tests/Generator/Model/MakeWithOptionsTest.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Support\Path;
 
 beforeEach(function () {
     Config::set('ddd.domain_path', 'src/Domain');

--- a/tests/Generator/RequestMakeTest.php
+++ b/tests/Generator/RequestMakeTest.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 beforeEach(function () {
     Config::set([

--- a/tests/Generator/ValueObjectMakeTest.php
+++ b/tests/Generator/ValueObjectMakeTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
-use Lunarstorm\LaravelDDD\Tests\Fixtures\Enums\Feature;
+use Tey\LaravelDDD\Tests\Fixtures\Enums\Feature;
 
 it('can generate value objects', function ($domainPath, $domainRoot) {
     Config::set('ddd.domain_path', $domainPath);

--- a/tests/Migration/MigrationPruneTest.php
+++ b/tests/Migration/MigrationPruneTest.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
-use Lunarstorm\LaravelDDD\Events\DomainMigrationsPruned;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Events\DomainMigrationsPruned;
+use Tey\LaravelDDD\Support\Path;
 
 it('prunes domain migrations when schema:dump --prune is called', function () {
     $this->setupTestApplication();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Tests\TestCase;
+use Tey\LaravelDDD\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
 

--- a/tests/Support/AutoloaderTest.php
+++ b/tests/Support/AutoloaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Support\AutoloadManager;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\AutoloadManager;
+use Tey\LaravelDDD\Support\Path;
 
 beforeEach(function () {
     $this->setupTestApplication();

--- a/tests/Support/BlueprintTest.php
+++ b/tests/Support/BlueprintTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Support\GeneratorBlueprint;
+use Tey\LaravelDDD\Support\GeneratorBlueprint;
 
 beforeEach(function () {
     config()->set([

--- a/tests/Support/CacheTest.php
+++ b/tests/Support/CacheTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\File;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\Support\DomainCache;
 
 beforeEach(function () {
     $cacheDirectory = config('ddd.cache_directory', 'bootstrap/cache/ddd');

--- a/tests/Support/DomainResolverTest.php
+++ b/tests/Support/DomainResolverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\DomainResolver;
 
 beforeEach(function () {
     $this->artisan('ddd:model', [

--- a/tests/Support/DomainTest.php
+++ b/tests/Support/DomainTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\Domain;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\Domain;
+use Tey\LaravelDDD\Support\Path;
 
 it('can initialize a domain', function ($domainName, $subdomainName) {
     $domain = new Domain($domainName, $subdomainName);

--- a/tests/Support/ResolveLayerTest.php
+++ b/tests/Support/ResolveLayerTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
-use Lunarstorm\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\Path;
 
 beforeEach(function () {
     Config::set('ddd.domain_path', 'src/Domain');

--- a/tests/Support/ResolveObjectSchemaUsingTest.php
+++ b/tests/Support/ResolveObjectSchemaUsingTest.php
@@ -2,9 +2,9 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Lunarstorm\LaravelDDD\Facades\DDD;
-use Lunarstorm\LaravelDDD\ValueObjects\CommandContext;
-use Lunarstorm\LaravelDDD\ValueObjects\ObjectSchema;
+use Tey\LaravelDDD\Facades\DDD;
+use Tey\LaravelDDD\ValueObjects\CommandContext;
+use Tey\LaravelDDD\ValueObjects\ObjectSchema;
 
 beforeEach(function () {
     $this->setupTestApplication();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,10 +7,10 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
-use Tey\LaravelDDD\LaravelDDDServiceProvider;
-use Tey\LaravelDDD\Support\DomainCache;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Symfony\Component\Process\Process;
+use Tey\LaravelDDD\LaravelDDDServiceProvider;
+use Tey\LaravelDDD\Support\DomainCache;
 
 class TestCase extends Orchestra
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Lunarstorm\LaravelDDD\Tests;
+namespace Tey\LaravelDDD\Tests;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
-use Lunarstorm\LaravelDDD\LaravelDDDServiceProvider;
-use Lunarstorm\LaravelDDD\Support\DomainCache;
+use Tey\LaravelDDD\LaravelDDDServiceProvider;
+use Tey\LaravelDDD\Support\DomainCache;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Symfony\Component\Process\Process;
 
@@ -28,7 +28,7 @@ class TestCase extends Orchestra
             $this->cleanSlate();
 
             Factory::guessFactoryNamesUsing(
-                fn (string $modelName) => 'Lunarstorm\\LaravelDDD\\Database\\Factories\\'.class_basename($modelName).'Factory'
+                fn (string $modelName) => 'Tey\\LaravelDDD\\Database\\Factories\\'.class_basename($modelName).'Factory'
             );
 
             DomainCache::clear();

--- a/tests/ValueObject/DomainObjectTest.php
+++ b/tests/ValueObject/DomainObjectTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Lunarstorm\LaravelDDD\Support\DomainResolver;
-use Lunarstorm\LaravelDDD\Support\Path;
-use Lunarstorm\LaravelDDD\ValueObjects\DomainObject;
+use Tey\LaravelDDD\Support\DomainResolver;
+use Tey\LaravelDDD\Support\Path;
+use Tey\LaravelDDD\ValueObjects\DomainObject;
 
 it('can create a domain object from resolvable class names', function (string $class, $domain, $relativeNamespace, $objectName) {
     $domainObject = DomainObject::fromClass($class);


### PR DESCRIPTION
This pull request introduces a major package rename and namespace update, migrating from `lunarstorm/laravel-ddd` to `tey/laravel-ddd`. All references throughout the codebase, documentation, configuration, and autoloading have been updated to reflect the new package name, PHP namespace, and repository location. This is a breaking change and requires consumers to update their dependencies and code imports accordingly.

**Package rename and namespace migration:**
- Renamed package from `lunarstorm/laravel-ddd` to `tey/laravel-ddd` in `composer.json`, updated the homepage, author email, and keywords, and changed the autoload and provider/alias namespaces from `Lunarstorm\LaravelDDD` to `Tey\LaravelDDD`. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R16) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L47-R53) [[3]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L81-R84)
- Updated all PHP namespaces in source, factory, and route files from `Lunarstorm\LaravelDDD` to `Tey\LaravelDDD`. [[1]](diffhunk://#diff-ca75ce29b8b6d5191a144091771cd4b0d2df7b2b02d484579a79d31895ebe6f8L3-R3) [[2]](diffhunk://#diff-42a88013dc8c8a00f32ceb7f016b7b59b0936c8da35039b4b29b3b465aab63beL4-R4) [[3]](diffhunk://#diff-956cc86d69df9071579f65895d7543297e604ecf362a2dcd20af92eaf4d767b2L3-R3) [[4]](diffhunk://#diff-c44f1988897aacff7431d1e320c40c1edd3bb7c6a07f9b33c7949dc2737a977dL3-R3) [[5]](diffhunk://#diff-9f0b98591a227166053d6b660dd845d3d35e800c2699717b63c4d17468fbcb66L3-R6) [[6]](diffhunk://#diff-82c2b873b49f8ae20282648fe411a13130227f5f54f8baa4993157ebfb8b1f1eL3-R5) [[7]](diffhunk://#diff-94dace860c5ec1ffa7543c9c55967383324004f039db8ee4b4ed0f1e9290cfd7L3-R3) [[8]](diffhunk://#diff-f4ddb825aa11db236d9e1ef5b39b683ddd4a1e21b6da74c489f4c9fd11f3cd17L3-R3) [[9]](diffhunk://#diff-d6d39f3fda0bd85e4b3f73661d6feee0d893b6c028a8d8b3ba4fb6bd2a43e373L3-R9) [[10]](diffhunk://#diff-c926bffd69355d9a67bfa3e89772ca7fb29a84b5bc80c3839916cfba19673a7bL3-R12) [[11]](diffhunk://#diff-707abbeed9d3f00d54d95552a1282513da1e03d5ea21079ae68cc5f73d77397cL3-R5) [[12]](diffhunk://#diff-284776d6eef3c383d1c9c3c6f742cf98c1d696156adc35cb5a8ef7fccc08f7fcL3-R6) [[13]](diffhunk://#diff-c48e6a2dcf7c55a75c0098d62f233810b2183b4f06dffcce3ef10fd60932bb8dL3-R6) [[14]](diffhunk://#diff-653b9f42984b086bdb96fb19c06a6dea901ee34842fcbe5ef111bae024821461L3-R7) [[15]](diffhunk://#diff-9e6d33874f700b793043a7493fee40e7d240c71c41fb77711a3661b97c41f0f3L3-R7)

**Documentation and metadata updates:**
- Updated `README.md` to reference the new package name, GitHub repository, Packagist links, and PHP namespaces in all code examples and documentation sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L277-R279) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L387-R387) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L418-R418)
- Updated `.github/ISSUE_TEMPLATE/config.yml` to point all support, feature, and bug report links to the new repository location.
- Added upgrade instructions in `UPGRADING.md` for migrating from 2.x to 3.0.0, including package and namespace changes.
- Added a changelog entry in `CHANGELOG.md` documenting the rename, namespace update, and repository move.