### PR TITLE
Allow Symfony 8 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "laravel/prompts": "^0.3.1",
         "lorisleiva/lody": "^0.6|^0.7",
         "spatie/laravel-package-tools": "^1.19.0",
-        "symfony/finder": "^7.0",
-        "symfony/var-exporter": "^7.1"
+        "symfony/finder": "^7.0|^8.0",
+        "symfony/var-exporter": "^7.1|^8.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.0.1|^3.0",


### PR DESCRIPTION
## Problem

`composer.json` declares Laravel 13 support (`illuminate/contracts: ^11.44|^12.0|^13.0`), but the Symfony constraints prevent that support from being usable in practice.

Laravel 13 requires `symfony/finder (^7.4.0 || ^8.0.0)` and resolves it to 8.x in a normal Laravel 13 application. Because this package pins `symfony/finder: ^7.0`, Composer refuses to install:

```
- tey/laravel-ddd[v3.0.0, ..., v3.0.1] require symfony/finder ^7.0 -> found
  symfony/finder[v7.0.0-BETA1, ..., 7.4.x-dev] but the package is fixed to
  v8.1.1 (lock file version)
```

Installing anyway forces `symfony/finder` back to 7.4, which works but holds the component a major version behind for no benefit.

Note this constraint is new in v3.0.0 — v2.1.2 did not require `symfony/finder` at all, so this only affects the v3 line.

## Change

Widens both Symfony constraints to accept 8.x:

```diff
-"symfony/finder": "^7.0",
-"symfony/var-exporter": "^7.1"
+"symfony/finder": "^7.0|^8.0",
+"symfony/var-exporter": "^7.1|^8.0"
```

## Why this is safe

Both components are consumed through APIs that are unchanged in 8.0:

**Finder** — `src/Support/DomainMigration.php`, `src/Support/AutoloadManager.php`, `src/Commands/UpgradeCommand.php` use only `Finder::create()`, `->files()`, `->in()`, `->name()`, and `SplFileInfo::getRelativePath()` / `getRelativePathname()`. The [Finder 8.x CHANGELOG](https://github.com/symfony/finder/blob/8.1/CHANGELOG.md) records no entry for 8.0 at all; the only 8.x addition is `Finder::useUnixPaths()` in 8.1.

**VarExporter** — `src/ConfigManager.php` uses only `VarExporter::export()`. The [8.0 removals](https://github.com/symfony/var-exporter/blob/8.1/CHANGELOG.md) are `LazyGhostTrait`, `LazyProxyTrait`, and the `ProxyHelper::generateLazyProxy()` restriction; none of these appear anywhere in `src/`.

The existing test matrix should confirm this against both major lines.