### PR TITLE
fix: resolve PHPStan failure under phpstan 2.2 / larastan 3.10

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - 'composer.json'
 
 jobs:
   phpstan:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,10 @@ includes:
 
 parameters:
     level: 4
+    # The package targets Laravel 11/12/13, whose Command::handle() PHPDoc return
+    # types differ. Treating those PHPDoc types as certain flags the defensive
+    # return-shape checks in HandleHooks as impossible, which they aren't at runtime.
+    treatPhpDocTypesAsCertain: false
     paths:
         - src
         - config

--- a/src/Commands/DomainModelMakeCommand.php
+++ b/src/Commands/DomainModelMakeCommand.php
@@ -45,7 +45,6 @@ class DomainModelMakeCommand extends ModelMakeCommand
 
         $this->afterHandle();
 
-        /** @phpstan-ignore-next-line function.impossibleType */
         return is_int($result) ? $result : self::SUCCESS;
     }
 


### PR DESCRIPTION
## Problem

PHPStan failed on the `v3.1.0` tag push ([run 30556026341](https://github.com/jaspertey/laravel-ddd/actions/runs/30556026341)) with two errors:

```
HandleHooks.php:38  is_int() with null      will always evaluate to false  (DomainNotificationMakeCommand)
HandleHooks.php:38  is_int() with true|null will always evaluate to false  (DomainRequestMakeCommand)
```

No PHP source changed between v3.0.1 and v3.1.0 — only `composer.json`, workflow YAML, and docs. The break came from **floating dev dependencies**, since `composer.lock` is gitignored and CI resolves fresh every run:

| Package | Previously | CI now resolves |
|---|---|---|
| phpstan/phpstan | 2.1.42 | **2.2.7** |
| larastan/larastan | v3.9.3 | **v3.10.0** |
| laravel/framework | v13.1.1 | **v13.23.0** |

Reproduced locally by resolving those exact versions. Symfony 8 is **not** involved — CI resolves `symfony/finder` and `symfony/var-exporter` at 7.4.14, since Laravel 13 constrains them to `^7.4`.

## Why the existing ignores stopped working

Both sites already carried `@phpstan-ignore-next-line function.impossibleType`. Those no longer suppress, because line-based ignores don't apply to trait errors reported *"in context of class X"*. Verified: dropping the identifier and using a bare `@phpstan-ignore-next-line` doesn't help either.

## Fix

`treatPhpDocTypesAsCertain: false`, which is PHPStan's own suggestion for this error and is semantically correct here — the certainty comes from PHPDoc, and this package targets Laravel 11/12/13 whose `Command::handle()` PHPDoc return types differ. The defensive return-shape handling in `HandleHooks` is genuinely reachable at runtime, so this is not a suppression. The ignore in `DomainModelMakeCommand` then becomes unmatched and is removed.

Also added `composer.json` to the PHPStan workflow's `paths` trigger. It previously fired only on `**.php` and `phpstan.neon.dist`, so a dependency-driven break couldn't trigger it — which is why this stayed latent from v3.0.1 until a tag push ran it against the full tree.

## Notes

- `v3.1.0` was tagged, released, and published to Packagist, then yanked (release + tag deleted, Packagist resynced). The 3.1.0 CHANGELOG entry is on `main` but unreleased; re-tag once this lands.
- Because the lock is gitignored, a future dependency release can break `main` with no repo change. A scheduled PHPStan run would catch that class of drift — not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)