### PR TITLE
fix: keep ddd:* generator command names on Laravel 13.24+

### DIFF
--- a/src/Commands/Concerns/ResolvesDomainFromInput.php
+++ b/src/Commands/Concerns/ResolvesDomainFromInput.php
@@ -3,6 +3,7 @@
 namespace Tey\LaravelDDD\Commands\Concerns;
 
 use Illuminate\Support\Str;
+use ReflectionClass;
 use Symfony\Component\Console\Input\InputOption;
 use Tey\LaravelDDD\Support\Domain;
 use Tey\LaravelDDD\Support\DomainResolver;
@@ -18,12 +19,25 @@ trait ResolvesDomainFromInput
 
     protected $nameIsAbsolute = false;
 
-    protected function getOptions()
+    protected function configure(): void
     {
-        return [
-            ...parent::getOptions(),
-            ['domain', null, InputOption::VALUE_OPTIONAL, 'The domain name'],
-        ];
+        parent::configure();
+
+        // Since Laravel 13.24, the framework's generator commands declare their
+        // definition via $signature (laravel/framework#60926), which takes
+        // precedence over $name and skips getOptions() entirely. Configuring
+        // against the built definition survives both declaration styles, but
+        // by this point the fluent path has already overwritten $this->name
+        // with the parsed signature name, so recover it from the class default.
+        if ($name = (new ReflectionClass(static::class))->getDefaultProperties()['name'] ?? null) {
+            $this->setName($this->name = $name);
+        }
+
+        if (! $this->getDefinition()->hasOption('domain')) {
+            $this->getDefinition()->addOption(
+                new InputOption('domain', null, InputOption::VALUE_OPTIONAL, 'The domain name')
+            );
+        }
     }
 
     protected function rootNamespace()

--- a/src/Commands/DomainModelMakeCommand.php
+++ b/src/Commands/DomainModelMakeCommand.php
@@ -23,7 +23,7 @@ class DomainModelMakeCommand extends ModelMakeCommand
     }
 
     /**
-     * @return int
+     * @return bool|null
      */
     public function handle()
     {
@@ -37,15 +37,14 @@ class DomainModelMakeCommand extends ModelMakeCommand
         if (! $this->option('force') && $this->alreadyExists($this->getNameInput())) {
             $this->components->error($this->type.' already exists.');
 
-            return self::FAILURE;
+            return false;
         }
 
-        /** @phpstan-ignore-next-line staticMethod.void */
         $result = parent::handle();
 
         $this->afterHandle();
 
-        return is_int($result) ? $result : self::SUCCESS;
+        return is_bool($result) ? $result : null;
     }
 
     protected function buildFactoryReplacements()

--- a/tests/Command/RegistrationTest.php
+++ b/tests/Command/RegistrationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Tey\LaravelDDD\Commands;
+
+// Regression test for https://github.com/jaspertey/laravel-ddd/issues/115
+// Laravel 13.24 consolidated the framework generator command definitions
+// into $signature (laravel/framework#60926), which caused the extending
+// ddd:* commands to register under their parent's make:* name instead.
+
+dataset('domainGenerators', [
+    'ddd:model' => ['ddd:model', Commands\DomainModelMakeCommand::class],
+    'ddd:factory' => ['ddd:factory', Commands\DomainFactoryMakeCommand::class],
+    'ddd:cast' => ['ddd:cast', Commands\DomainCastMakeCommand::class],
+    'ddd:channel' => ['ddd:channel', Commands\DomainChannelMakeCommand::class],
+    'ddd:class' => ['ddd:class', Commands\DomainClassMakeCommand::class],
+    'ddd:command' => ['ddd:command', Commands\DomainConsoleMakeCommand::class],
+    'ddd:controller' => ['ddd:controller', Commands\DomainControllerMakeCommand::class],
+    'ddd:enum' => ['ddd:enum', Commands\DomainEnumMakeCommand::class],
+    'ddd:event' => ['ddd:event', Commands\DomainEventMakeCommand::class],
+    'ddd:exception' => ['ddd:exception', Commands\DomainExceptionMakeCommand::class],
+    'ddd:interface' => ['ddd:interface', Commands\DomainInterfaceMakeCommand::class],
+    'ddd:job' => ['ddd:job', Commands\DomainJobMakeCommand::class],
+    'ddd:listener' => ['ddd:listener', Commands\DomainListenerMakeCommand::class],
+    'ddd:mail' => ['ddd:mail', Commands\DomainMailMakeCommand::class],
+    'ddd:middleware' => ['ddd:middleware', Commands\DomainMiddlewareMakeCommand::class],
+    'ddd:notification' => ['ddd:notification', Commands\DomainNotificationMakeCommand::class],
+    'ddd:observer' => ['ddd:observer', Commands\DomainObserverMakeCommand::class],
+    'ddd:policy' => ['ddd:policy', Commands\DomainPolicyMakeCommand::class],
+    'ddd:provider' => ['ddd:provider', Commands\DomainProviderMakeCommand::class],
+    'ddd:request' => ['ddd:request', Commands\DomainRequestMakeCommand::class],
+    'ddd:resource' => ['ddd:resource', Commands\DomainResourceMakeCommand::class],
+    'ddd:rule' => ['ddd:rule', Commands\DomainRuleMakeCommand::class],
+    'ddd:scope' => ['ddd:scope', Commands\DomainScopeMakeCommand::class],
+    'ddd:seeder' => ['ddd:seeder', Commands\DomainSeederMakeCommand::class],
+    'ddd:trait' => ['ddd:trait', Commands\DomainTraitMakeCommand::class],
+    'ddd:migration' => ['ddd:migration', Commands\Migration\DomainMigrateMakeCommand::class],
+]);
+
+it('registers the generator under its ddd name with a --domain option', function (string $name, string $class) {
+    $commands = Artisan::all();
+
+    expect($commands)->toHaveKey($name);
+    expect($commands[$name])->toBeInstanceOf($class);
+    expect($commands[$name]->getName())->toBe($name);
+    expect($commands[$name]->getDefinition()->hasOption('domain'))->toBeTrue();
+})->with('domainGenerators');
+
+it('does not override the native framework generator command', function () {
+    $commands = Artisan::all();
+
+    $native = [
+        'make:model',
+        'make:factory',
+        'make:cast',
+        'make:channel',
+        'make:class',
+        'make:command',
+        'make:controller',
+        'make:enum',
+        'make:event',
+        'make:exception',
+        'make:interface',
+        'make:job',
+        'make:listener',
+        'make:mail',
+        'make:middleware',
+        'make:notification',
+        'make:observer',
+        'make:policy',
+        'make:provider',
+        'make:request',
+        'make:resource',
+        'make:rule',
+        'make:scope',
+        'make:seeder',
+        'make:trait',
+        'make:migration',
+    ];
+
+    foreach ($native as $name) {
+        expect($commands)->toHaveKey($name);
+
+        expect(get_class($commands[$name]))
+            ->not->toStartWith('Tey\\LaravelDDD\\', "[{$name}] should not resolve to a package command");
+    }
+});


### PR DESCRIPTION
This pull request addresses compatibility with recent changes in Laravel's generator command registration, ensuring that all `ddd:*` generator commands are correctly registered under their intended names and retain the `--domain` option, while not overriding native framework commands. It also includes a regression test to prevent future issues and improves the handling of command result codes.

**Command registration and compatibility fixes:**

* Refactored the `ResolvesDomainFromInput` trait to add the `--domain` option and set the command name within the `configure()` method, ensuring compatibility with Laravel 13.24+ where command definitions are consolidated in `$signature` and `getOptions()` is no longer used. This prevents `ddd:*` commands from being registered under their parent `make:*` names. [[1]](diffhunk://#diff-d6d39f3fda0bd85e4b3f73661d6feee0d893b6c028a8d8b3ba4fb6bd2a43e373R6) [[2]](diffhunk://#diff-d6d39f3fda0bd85e4b3f73661d6feee0d893b6c028a8d8b3ba4fb6bd2a43e373L21-R40)

**Testing and regression prevention:**

* Added a regression test in `tests/Command/RegistrationTest.php` to verify that all `ddd:*` generator commands are registered under their correct names with the `--domain` option, and to ensure that native `make:*` commands are not overridden by package commands.

**Command result handling:**

* Updated `DomainModelMakeCommand::handle()` to return `false` instead of a failure code when the model already exists, and to return `null` for successful execution, reflecting the expected return types and improving code clarity. [[1]](diffhunk://#diff-0f68a330a0b87dc18fc2f22c00e5b2a191d62313cf44e355a0cdd63ffc43ff2aL26-R26) [[2]](diffhunk://#diff-0f68a330a0b87dc18fc2f22c00e5b2a191d62313cf44e355a0cdd63ffc43ff2aL40-R47)